### PR TITLE
[FEAT] 리뷰 작성 플로우 UI 구현

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -35,20 +35,36 @@ export default function RootLayout() {
             />
 
             <Stack.Screen
+              name="review/[placeId]/result"
+              options={{
+                headerShown: false,
+                presentation: "transparentModal",
+                animation: "fade",
+              }}
+            />
+            <Stack.Screen
               name="review/[placeId]/receipt"
-              options={{ title: "영수증 인증" }}
+              options={{
+                title: "1 / 3",
+                headerTitleAlign: "center",
+                headerShadowVisible: false,
+              }}
             />
             <Stack.Screen
               name="review/[placeId]/photo"
-              options={{ title: "사진 첨부" }}
+              options={{ headerShown: false }}
             />
             <Stack.Screen
               name="review/[placeId]/form"
-              options={{ title: "리뷰 작성" }}
+              options={{
+                title: "3 / 3",
+                headerTitleAlign: "center",
+                headerShadowVisible: false,
+              }}
             />
             <Stack.Screen
               name="review/[placeId]/done"
-              options={{ title: "작성 완료", headerBackVisible: false }}
+              options={{ headerShown: false }}
             />
 
             <Stack.Screen

--- a/src/app/review/[placeId]/done.tsx
+++ b/src/app/review/[placeId]/done.tsx
@@ -1,9 +1,226 @@
-import { useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { PawPrint } from "lucide-react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { ScreenStub } from "@/components/screen-stub";
+import { AlternativePlaceCard } from "@/components/review/alternative-place-card";
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { getAlternativePlaces, MOCK_PLACES } from "@/mocks/places";
+import { useReviewDraft } from "@/stores/review-draft";
 
 export default function ReviewDoneScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
 
-  return <ScreenStub name="작성 완료" detail={`placeId: ${placeId}`} />;
+  const result = useReviewDraft((state) => state.result);
+  const size = useReviewDraft((state) => state.size);
+  const reset = useReviewDraft((state) => state.reset);
+
+  const place = MOCK_PLACES.find((item) => item.id === placeId);
+  const placeName = place?.name ?? "이 가게";
+  const allowed = result === "allowed";
+
+  const leave = (to: "/map" | "/my") => {
+    reset();
+    router.dismissAll();
+    router.navigate(to);
+  };
+
+  // dismissAll·reset 금지 — 상세에서 뒤로가기 시 완료 화면 유지.
+  const openStore = (targetId: string) => {
+    router.push({
+      pathname: "/store/[placeId]",
+      params: { placeId: targetId },
+    });
+  };
+
+  const altSize = size ?? "smallMedium";
+  const alternatives = allowed ? [] : getAlternativePlaces(placeId, altSize, 3);
+
+  return (
+    <View style={styles.root}>
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.content,
+          allowed
+            ? {
+                justifyContent: "center",
+                paddingTop: insets.top,
+                paddingBottom: insets.bottom + 96,
+              }
+            : { paddingTop: insets.top + Spacing.six },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {allowed ? (
+          <View style={styles.heroGroup}>
+            <ThemedText type="head03" color={Palette.gray[700]}>
+              리뷰 작성 완료
+            </ThemedText>
+            <Pressable
+              onPress={() => openStore(placeId)}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={`${placeName} 상세 보기`}
+            >
+              <ThemedText
+                type="subtitle03"
+                color={Palette.gray[500]}
+                style={styles.storeName}
+              >
+                {placeName}
+              </ThemedText>
+            </Pressable>
+
+            <View style={styles.stampCircle}>
+              <PawPrint size={56} color={Palette.main[400]} />
+            </View>
+
+            <ThemedText type="subtitle01" color={Palette.gray[700]}>
+              스탬프를 받았어요!
+            </ThemedText>
+            <ThemedText type="label04" color={Palette.gray[400]}>
+              소중한 리뷰가 지도에 반영되었어요
+            </ThemedText>
+          </View>
+        ) : (
+          <View style={styles.deniedGroup}>
+            <View style={styles.heroGroup}>
+              <ThemedText type="head03" color={Palette.gray[700]}>
+                리뷰 작성 완료
+              </ThemedText>
+              <Pressable
+                onPress={() => openStore(placeId)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={`${placeName} 상세 보기`}
+              >
+                <ThemedText
+                  type="subtitle03"
+                  color={Palette.gray[500]}
+                  style={styles.storeName}
+                >
+                  {placeName}
+                </ThemedText>
+              </Pressable>
+              <ThemedText type="label04" color={Palette.gray[400]}>
+                소중한 리뷰가 지도에 반영되었어요
+              </ThemedText>
+            </View>
+
+            <View style={styles.divider} />
+
+            <ThemedText type="subtitle02" color={Palette.gray[700]}>
+              인근에 이런 곳은 어때요?
+            </ThemedText>
+
+            {alternatives.length > 0 ? (
+              <View style={styles.cardList}>
+                {alternatives.map((alt) => (
+                  <AlternativePlaceCard
+                    key={alt.id}
+                    place={alt}
+                    size={altSize}
+                    onPress={openStore}
+                  />
+                ))}
+              </View>
+            ) : (
+              <View style={styles.emptyBox}>
+                <ThemedText type="label04" color={Palette.gray[400]}>
+                  근처에 추천할 만한 곳을 아직 못 찾았어요
+                </ThemedText>
+              </View>
+            )}
+          </View>
+        )}
+      </ScrollView>
+
+      <View
+        style={[styles.footer, { paddingBottom: insets.bottom + Spacing.two }]}
+      >
+        {allowed ? (
+          <View style={styles.footerRow}>
+            <Button
+              label="닫기"
+              variant="secondary"
+              onPress={() => leave("/map")}
+              style={styles.flexButton}
+            />
+            <Button
+              label="여권 확인하러 가기"
+              variant="primary"
+              onPress={() => leave("/my")}
+              style={styles.flexButton}
+            />
+          </View>
+        ) : (
+          <Button
+            label="닫기"
+            variant="secondary"
+            onPress={() => leave("/map")}
+          />
+        )}
+      </View>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  content: {
+    flexGrow: 1,
+    padding: Spacing.four,
+    paddingBottom: Spacing.six,
+  },
+  heroGroup: {
+    alignItems: "center",
+    gap: Spacing.three,
+  },
+  storeName: {
+    textDecorationLine: "underline",
+  },
+  stampCircle: {
+    width: 180,
+    height: 180,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: "rgba(255, 154, 134, 0.14)",
+    marginVertical: Spacing.four,
+  },
+  deniedGroup: {
+    gap: Spacing.four,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Palette.border.disabled,
+  },
+  cardList: {
+    gap: Spacing.three,
+  },
+  emptyBox: {
+    alignItems: "center",
+    paddingVertical: Spacing.five,
+  },
+  footer: {
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+    backgroundColor: Palette.background.base,
+  },
+  footerRow: {
+    flexDirection: "row",
+    gap: Spacing.two,
+  },
+  flexButton: {
+    flex: 1,
+  },
+});

--- a/src/app/review/[placeId]/form.tsx
+++ b/src/app/review/[placeId]/form.tsx
@@ -1,9 +1,301 @@
-import { useLocalSearchParams } from "expo-router";
+import { type ReactNode } from "react";
 
-import { ScreenStub } from "@/components/screen-stub";
+import { Image } from "expo-image";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Camera } from "lucide-react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { ReviewHeaderTitle } from "@/components/review/review-header-title";
+import { ReviewResultBadge } from "@/components/review/review-result-badge";
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { SelectChip } from "@/components/ui/select-chip";
+import { TextField } from "@/components/ui/text-field";
+import { HASHTAGS } from "@/constants/hashtags";
+import { SIZE_LABEL } from "@/constants/status";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { MOCK_PLACES } from "@/mocks/places";
+import { useReviewDraft } from "@/stores/review-draft";
+import type { SizeKey } from "@/types/place";
+
+const MIN_CONTENT = 10;
+const MAX_CONTENT = 50;
+
+const SIZE_ORDER: SizeKey[] = ["smallMedium", "large"];
 
 export default function ReviewFormScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
 
-  return <ScreenStub name="리뷰 작성" detail={`placeId: ${placeId}`} />;
+  const result = useReviewDraft((state) => state.result);
+  const photoUri = useReviewDraft((state) => state.photoUri);
+  const size = useReviewDraft((state) => state.size);
+  const tags = useReviewDraft((state) => state.tags);
+  const content = useReviewDraft((state) => state.content);
+  const setSize = useReviewDraft((state) => state.setSize);
+  const toggleTag = useReviewDraft((state) => state.toggleTag);
+  const setContent = useReviewDraft((state) => state.setContent);
+
+  const place = MOCK_PLACES.find((item) => item.id === placeId);
+  const placeName = place?.name ?? "이 가게";
+  const allowed = result === "allowed";
+  const canSubmit = size !== null && content.trim().length >= MIN_CONTENT;
+
+  const submit = () => {
+    if (!canSubmit) {
+      return;
+    }
+    router.push({ pathname: "/review/[placeId]/done", params: { placeId } });
+  };
+
+  return (
+    <View style={styles.root}>
+      <Stack.Screen
+        options={{
+          headerTitle: () => <ReviewHeaderTitle placeName={placeName} />,
+        }}
+      />
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.content,
+          { paddingBottom: insets.bottom + 120 },
+        ]}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.badgeRow}>
+          <ReviewResultBadge
+            allowed={allowed}
+            textType="subtitle04"
+            paddingVertical={6}
+            paddingHorizontal={Spacing.three}
+            iconSize={15}
+          />
+        </View>
+
+        {allowed && photoUri ? (
+          <View style={styles.photoWrap}>
+            <Image
+              source={{ uri: photoUri }}
+              style={styles.photo}
+              contentFit="cover"
+              transition={150}
+              accessibilityLabel="촬영한 반려견 사진"
+            />
+            <Pressable
+              onPress={() => router.back()}
+              hitSlop={6}
+              accessibilityRole="button"
+              accessibilityLabel="사진 다시 찍기"
+              style={styles.retakeButton}
+            >
+              <Camera size={14} color={Palette.white} />
+              <ThemedText type="label06" color={Palette.white}>
+                다시 찍기
+              </ThemedText>
+            </Pressable>
+          </View>
+        ) : null}
+
+        <Field title="견종 크기" required>
+          <View style={styles.chipRow}>
+            {SIZE_ORDER.map((value) => (
+              <SelectChip
+                key={value}
+                label={SIZE_LABEL[value]}
+                selected={size === value}
+                onPress={() => setSize(value)}
+              />
+            ))}
+          </View>
+        </Field>
+
+        {allowed ? (
+          <Field title="해시태그" caption="선택">
+            <View style={styles.chipWrap}>
+              {HASHTAGS.map((tag) => (
+                <SelectChip
+                  key={tag}
+                  label={`#${tag}`}
+                  selected={tags.includes(tag)}
+                  onPress={() => toggleTag(tag)}
+                />
+              ))}
+            </View>
+          </Field>
+        ) : null}
+
+        <Field
+          title={allowed ? "한마디" : "어떤 상황이었나요?"}
+          required
+          caption="10자 이상 작성해 주세요"
+          trailing={
+            <ThemedText type="label05" color={Palette.gray[400]}>
+              {content.trim().length} / {MAX_CONTENT}
+            </ThemedText>
+          }
+        >
+          <TextField
+            value={content}
+            onChangeText={setContent}
+            placeholder={
+              allowed
+                ? "사장님이 물그릇을 챙겨주셨어요"
+                : "거절 사유를 적어주세요"
+            }
+            multiline
+            maxLength={MAX_CONTENT}
+            focusColor={allowed ? Palette.black : Palette.main[500]}
+            style={styles.textarea}
+          />
+        </Field>
+
+        {!allowed ? (
+          <View style={styles.warningBox}>
+            <ThemedText type="subtitle04" color={Palette.error[300]}>
+              허위 리뷰는 가게에 피해가 될 수 있어요 ㅜㅜ
+            </ThemedText>
+            <ThemedText type="label05" color={Palette.error[300]}>
+              악의적인 허위 리뷰 도배가 확인되면 계정이 정지될 수 있어요.
+            </ThemedText>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      <View
+        style={[styles.footer, { paddingBottom: insets.bottom + Spacing.two }]}
+      >
+        <Button
+          label="리뷰 등록하기"
+          variant="main"
+          disabled={!canSubmit}
+          onPress={submit}
+        />
+      </View>
+    </View>
+  );
 }
+
+function Field({
+  title,
+  required,
+  caption,
+  trailing,
+  children,
+}: {
+  title: string;
+  required?: boolean;
+  caption?: string;
+  trailing?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <View style={styles.field}>
+      <View style={styles.fieldHeader}>
+        <ThemedText type="subtitle03" color={Palette.gray[700]}>
+          {title}
+          {required ? (
+            <ThemedText type="subtitle03" color={Palette.main[500]}>
+              {" *"}
+            </ThemedText>
+          ) : null}
+        </ThemedText>
+        {caption ? (
+          <ThemedText type="label05" color={Palette.gray[400]}>
+            {caption}
+          </ThemedText>
+        ) : null}
+        <View style={styles.fieldSpacer} />
+        {trailing}
+      </View>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  content: {
+    gap: Spacing.four,
+    padding: Spacing.four,
+  },
+  field: {
+    gap: Spacing.three,
+  },
+  fieldHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+  },
+  fieldSpacer: {
+    flex: 1,
+  },
+  badgeRow: {
+    flexDirection: "row",
+  },
+  photoWrap: {
+    height: 220,
+    borderRadius: Radius.large,
+    overflow: "hidden",
+    backgroundColor: Palette.gray[100],
+  },
+  photo: {
+    width: "100%",
+    height: "100%",
+  },
+  retakeButton: {
+    position: "absolute",
+    top: Spacing.two,
+    right: Spacing.two,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.half,
+    paddingVertical: Spacing.one,
+    paddingHorizontal: Spacing.two,
+    borderRadius: Radius.pill,
+    backgroundColor: "rgba(34, 34, 34, 0.6)",
+  },
+  chipRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: Spacing.two,
+  },
+  chipWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    rowGap: 12,
+    columnGap: Spacing.two,
+  },
+  textarea: {
+    minHeight: 120,
+    textAlignVertical: "top",
+  },
+  footer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    gap: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+    borderTopWidth: 1,
+    borderTopColor: Palette.border.disabled,
+    backgroundColor: Palette.background.base,
+  },
+  warningBox: {
+    marginTop: -Spacing.two,
+    gap: Spacing.one,
+    padding: Spacing.three,
+    borderRadius: Radius.medium,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: Palette.error[200],
+    backgroundColor: Palette.error[100],
+  },
+});

--- a/src/app/review/[placeId]/form.tsx
+++ b/src/app/review/[placeId]/form.tsx
@@ -30,6 +30,7 @@ export default function ReviewFormScreen() {
   const insets = useSafeAreaInsets();
 
   const result = useReviewDraft((state) => state.result);
+  const receipt = useReviewDraft((state) => state.receipt);
   const photoUri = useReviewDraft((state) => state.photoUri);
   const size = useReviewDraft((state) => state.size);
   const tags = useReviewDraft((state) => state.tags);
@@ -41,7 +42,12 @@ export default function ReviewFormScreen() {
   const place = MOCK_PLACES.find((item) => item.id === placeId);
   const placeName = place?.name ?? "이 가게";
   const allowed = result === "allowed";
-  const canSubmit = size !== null && content.trim().length >= MIN_CONTENT;
+  // 들어갔어요는 영수증 인증·사진까지 끝난 경우에만 등록 가능(선행 단계 검증).
+  const prerequisitesMet =
+    result === "denied" ||
+    (result === "allowed" && receipt.verified && photoUri !== null);
+  const canSubmit =
+    prerequisitesMet && size !== null && content.trim().length >= MIN_CONTENT;
 
   const submit = () => {
     if (!canSubmit) {

--- a/src/app/review/[placeId]/photo.tsx
+++ b/src/app/review/[placeId]/photo.tsx
@@ -1,9 +1,128 @@
-import { useLocalSearchParams } from "expo-router";
+import { Image } from "expo-image";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { ArrowLeft } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { ScreenStub } from "@/components/screen-stub";
+import { CameraCapture } from "@/components/review/camera-capture";
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { useReviewDraft } from "@/stores/review-draft";
+
+const SAMPLE_PHOTO_URI = "https://picsum.photos/seed/walwang-dog/900/1200";
 
 export default function PhotoScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
 
-  return <ScreenStub name="사진 첨부" detail={`placeId: ${placeId}`} />;
+  const photoUri = useReviewDraft((state) => state.photoUri);
+  const setPhotoUri = useReviewDraft((state) => state.setPhotoUri);
+
+  const goForm = () =>
+    router.push({ pathname: "/review/[placeId]/form", params: { placeId } });
+
+  if (photoUri) {
+    return (
+      <View style={styles.previewRoot}>
+        <Stack.Screen options={{ headerShown: false }} />
+
+        <View style={[styles.topBar, { paddingTop: insets.top + Spacing.two }]}>
+          <Pressable
+            onPress={() => setPhotoUri(null)}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="뒤로가기"
+          >
+            <ArrowLeft size={22} color={Palette.gray[700]} />
+          </Pressable>
+          <ThemedText type="subtitle03" color={Palette.gray[700]}>
+            반려견 사진 촬영
+          </ThemedText>
+          <View style={styles.topSpacer} />
+        </View>
+
+        <View style={styles.previewBody}>
+          <Image
+            source={{ uri: photoUri }}
+            style={styles.previewImage}
+            contentFit="cover"
+            transition={150}
+            accessibilityLabel="촬영한 반려견 사진"
+          />
+        </View>
+
+        <View
+          style={[
+            styles.previewFooter,
+            { paddingBottom: insets.bottom + Spacing.two },
+          ]}
+        >
+          <Button
+            label="다시 찍기"
+            variant="secondary"
+            onPress={() => setPhotoUri(null)}
+            style={styles.flexButton}
+          />
+          <Button
+            label="다음"
+            variant="primary"
+            onPress={goForm}
+            style={styles.flexButton}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <CameraCapture
+        title="반려견 사진 촬영"
+        hint={"반려견이 잘 보이게 찍어주세요\n스탬프는 이 사진에서 만들어져요"}
+        fallbackUri={SAMPLE_PHOTO_URI}
+        onCapture={setPhotoUri}
+        onBack={() => router.back()}
+      />
+    </>
+  );
 }
+
+const styles = StyleSheet.create({
+  previewRoot: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  topBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.four,
+    paddingBottom: Spacing.three,
+  },
+  topSpacer: {
+    width: 22,
+  },
+  previewBody: {
+    flex: 1,
+    padding: Spacing.four,
+    justifyContent: "center",
+  },
+  previewImage: {
+    width: "100%",
+    height: "100%",
+    borderRadius: Radius.large,
+    backgroundColor: Palette.gray[100],
+  },
+  previewFooter: {
+    flexDirection: "row",
+    gap: Spacing.two,
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+  },
+  flexButton: {
+    flex: 1,
+  },
+});

--- a/src/app/review/[placeId]/receipt.tsx
+++ b/src/app/review/[placeId]/receipt.tsx
@@ -1,11 +1,358 @@
-import { useLocalSearchParams } from "expo-router";
+import { useState } from "react";
 
-import { ScreenStub } from "@/components/screen-stub";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { ArrowLeft, Check } from "lucide-react-native";
+import { Modal, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { CameraCapture } from "@/components/review/camera-capture";
+import { ReviewHeaderTitle } from "@/components/review/review-header-title";
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { MOCK_PLACES } from "@/mocks/places";
+import { mockVerifyReceipt, type ReceiptOutcome } from "@/mocks/receipt";
+import { useReviewDraft } from "@/stores/review-draft";
+
+const SAMPLE_RECEIPT_URI = "https://picsum.photos/seed/walwang-receipt/600/900";
+
+type ReceiptFailure = "unreadable" | "mismatch";
+
+/** S-06 영수증 OCR 인증. OCR은 API라 결과만 목으로 흉내 낸다(mockVerifyReceipt). */
 export default function ReceiptScreen() {
-  // [주의] useLocalSearchParams의 값은 항상 string | string[] 이다.
-  // 숫자로 쓸 거면 반드시 Number()로 변환할 것.
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
 
-  return <ScreenStub name="영수증 인증" detail={`placeId: ${placeId}`} />;
+  const setReceipt = useReviewDraft((state) => state.setReceipt);
+  const resetReceipt = useReviewDraft((state) => state.resetReceipt);
+
+  const [verified, setVerified] = useState(false);
+  const [failure, setFailure] = useState<ReceiptFailure | null>(null);
+  const [mismatchName, setMismatchName] = useState<string | null>(null);
+
+  const place = MOCK_PLACES.find((item) => item.id === placeId);
+  const placeName = place?.name ?? "이 가게";
+
+  const applyOutcome = (outcome: ReceiptOutcome, imageUri: string) => {
+    if (!place) {
+      return;
+    }
+    const verdict = mockVerifyReceipt(place, outcome);
+
+    if (verdict.verified) {
+      setReceipt({
+        verified: true,
+        imageUri,
+        matchedName: verdict.matchedName,
+        token: verdict.receiptToken,
+      });
+      setVerified(true);
+      return;
+    }
+
+    resetReceipt();
+    if (verdict.reason === "OCR_FAILED") {
+      setFailure("unreadable");
+    } else {
+      setMismatchName(verdict.matchedName);
+      setFailure("mismatch");
+    }
+  };
+
+  const goPhoto = () =>
+    router.push({ pathname: "/review/[placeId]/photo", params: { placeId } });
+
+  const reselectStore = () => {
+    router.dismissAll();
+    router.navigate("/map");
+  };
+
+  if (verified) {
+    return (
+      <View style={styles.root}>
+        <Stack.Screen
+          options={{
+            headerShown: true,
+            headerBackVisible: false,
+            headerTitle: () => <ReviewHeaderTitle placeName={placeName} />,
+            headerLeft: () => (
+              <Pressable
+                onPress={() => setVerified(false)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="다시 촬영"
+              >
+                <ArrowLeft size={22} color={Palette.gray[700]} />
+              </Pressable>
+            ),
+          }}
+        />
+
+        <ScrollView
+          contentContainerStyle={[
+            styles.content,
+            { paddingBottom: insets.bottom + 120 },
+          ]}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.verifiedBlock}>
+            <View style={styles.checkCircle}>
+              <Check
+                size={36}
+                color={Palette.status.allowed[300]}
+                strokeWidth={3}
+              />
+            </View>
+
+            <View style={styles.titleGroup}>
+              <ThemedText
+                type="head03"
+                color={Palette.gray[700]}
+                style={styles.center}
+              >
+                영수증 인증이 완료됐어요
+              </ThemedText>
+              <ThemedText
+                type="label04"
+                color={Palette.gray[400]}
+                style={styles.center}
+              >
+                {placeName} · 상호명 확인 완료
+              </ThemedText>
+            </View>
+          </View>
+        </ScrollView>
+
+        <View
+          style={[
+            styles.footer,
+            { paddingBottom: insets.bottom + Spacing.two },
+          ]}
+        >
+          <Button
+            label="반려견 사진 찍기"
+            variant="primary"
+            onPress={goPhoto}
+          />
+          <ThemedText
+            type="label05"
+            color={Palette.gray[400]}
+            style={styles.footerHint}
+          >
+            사진은 스탬프 재료로 쓰여요
+          </ThemedText>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <CameraCapture
+        title="영수증 사진 촬영"
+        hint={"상호명이 잘 나오도록 촬영해주세요.\n금액·날짜는 보지 않아요."}
+        fallbackUri={SAMPLE_RECEIPT_URI}
+        onCapture={(uri) => applyOutcome("verified", uri)}
+        onBack={() => router.back()}
+        overlay={
+          __DEV__ ? (
+            <DevOutcomeRow
+              onPick={(outcome) => applyOutcome(outcome, SAMPLE_RECEIPT_URI)}
+            />
+          ) : null
+        }
+      />
+
+      <Modal
+        visible={failure !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setFailure(null)}
+      >
+        <View style={styles.modalRoot}>
+          <View style={styles.modalCard}>
+            {failure === "mismatch" ? (
+              <>
+                <ThemedText
+                  type="subtitle02"
+                  color={Palette.gray[700]}
+                  style={styles.modalText}
+                >
+                  이 가게가 아닌 것 같아요
+                </ThemedText>
+                <ThemedText
+                  type="label04"
+                  color={Palette.gray[400]}
+                  style={styles.modalText}
+                >
+                  {mismatchName
+                    ? `영수증 상호명: ${mismatchName}`
+                    : "영수증 상호명이 선택한 가게와 달라요"}
+                </ThemedText>
+                <View style={styles.modalActions}>
+                  <Button
+                    label="가게 다시 선택"
+                    variant="secondary"
+                    onPress={reselectStore}
+                    style={styles.modalButton}
+                  />
+                  <Button
+                    label="다시 촬영하기"
+                    variant="primary"
+                    onPress={() => setFailure(null)}
+                    style={styles.modalButton}
+                  />
+                </View>
+              </>
+            ) : (
+              <>
+                <ThemedText
+                  type="subtitle02"
+                  color={Palette.gray[700]}
+                  style={styles.modalText}
+                >
+                  영수증을 읽지 못했어요
+                </ThemedText>
+                <ThemedText
+                  type="label04"
+                  color={Palette.gray[400]}
+                  style={styles.modalText}
+                >
+                  글씨가 잘 보이도록 다시 촬영해주세요
+                </ThemedText>
+                <View style={styles.modalActions}>
+                  <Button
+                    label="닫기"
+                    variant="secondary"
+                    onPress={() => setFailure(null)}
+                    style={styles.modalButton}
+                  />
+                  <Button
+                    label="다시 촬영하기"
+                    variant="primary"
+                    onPress={() => setFailure(null)}
+                    style={styles.modalButton}
+                  />
+                </View>
+              </>
+            )}
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
 }
+
+/** [DEV 전용] OCR 결과 강제 — 실연동 시 제거. */
+function DevOutcomeRow({
+  onPick,
+}: {
+  onPick: (outcome: ReceiptOutcome) => void;
+}) {
+  const options: { label: string; outcome: ReceiptOutcome }[] = [
+    { label: "정상", outcome: "verified" },
+    { label: "불일치", outcome: "mismatch" },
+    { label: "판독실패", outcome: "unreadable" },
+  ];
+  return (
+    <View style={styles.devRow}>
+      <ThemedText type="label06" color="rgba(255,255,255,0.6)">
+        DEV
+      </ThemedText>
+      {options.map((option) => (
+        <Pressable
+          key={option.outcome}
+          onPress={() => onPick(option.outcome)}
+          hitSlop={6}
+          style={styles.devChip}
+        >
+          <ThemedText type="label06" color={Palette.white}>
+            {option.label}
+          </ThemedText>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  content: {
+    flexGrow: 1,
+    padding: Spacing.four,
+  },
+  verifiedBlock: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.four,
+  },
+  titleGroup: {
+    gap: Spacing.two,
+  },
+  center: {
+    textAlign: "center",
+  },
+  checkCircle: {
+    width: 76,
+    height: 76,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: Palette.status.allowed[100],
+  },
+  footer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+    backgroundColor: Palette.background.base,
+  },
+  footerHint: {
+    marginTop: Spacing.two,
+    textAlign: "center",
+  },
+  devRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.two,
+  },
+  devChip: {
+    paddingVertical: Spacing.half,
+    paddingHorizontal: Spacing.two,
+    borderRadius: Radius.small,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.4)",
+  },
+  modalRoot: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: Spacing.four,
+    backgroundColor: "rgba(34, 34, 34, 0.45)",
+  },
+  modalCard: {
+    gap: Spacing.two,
+    padding: Spacing.four,
+    borderRadius: Radius.large,
+    backgroundColor: Palette.white,
+  },
+  modalText: {
+    textAlign: "center",
+  },
+  modalActions: {
+    flexDirection: "row",
+    gap: Spacing.two,
+    marginTop: Spacing.two,
+  },
+  modalButton: {
+    flex: 1,
+  },
+});

--- a/src/app/review/[placeId]/result.tsx
+++ b/src/app/review/[placeId]/result.tsx
@@ -1,0 +1,129 @@
+import { useEffect } from "react";
+
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { X } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { MOCK_PLACES } from "@/mocks/places";
+import { useReviewDraft, type ReviewResult } from "@/stores/review-draft";
+
+export default function ReviewResultScreen() {
+  const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const router = useRouter();
+  const begin = useReviewDraft((state) => state.begin);
+  const setResult = useReviewDraft((state) => state.setResult);
+
+  const place = MOCK_PLACES.find((item) => item.id === placeId);
+
+  useEffect(() => {
+    if (placeId) {
+      begin(placeId);
+    }
+  }, [placeId, begin]);
+
+  const close = () => router.back();
+
+  const choose = (result: ReviewResult) => {
+    setResult(result);
+    if (result === "allowed") {
+      router.push({
+        pathname: "/review/[placeId]/receipt",
+        params: { placeId },
+      });
+    } else {
+      router.push({ pathname: "/review/[placeId]/form", params: { placeId } });
+    }
+  };
+
+  return (
+    <View style={styles.root}>
+      <Pressable
+        style={styles.backdrop}
+        onPress={close}
+        accessibilityRole="button"
+        accessibilityLabel="닫기"
+      />
+
+      <View style={styles.card}>
+        <Pressable
+          onPress={close}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="닫기"
+          style={styles.closeButton}
+        >
+          <X size={20} color={Palette.gray[400]} />
+        </Pressable>
+
+        <View style={styles.heading}>
+          <ThemedText type="subtitle01" color={Palette.gray[700]}>
+            들어갈 수 있었나요?
+          </ThemedText>
+          {place ? (
+            <ThemedText type="subtitle03" color={Palette.gray[400]}>
+              {place.name}
+            </ThemedText>
+          ) : null}
+        </View>
+
+        <View style={styles.actions}>
+          <Button
+            label="거절당했어요"
+            variant="secondary"
+            onPress={() => choose("denied")}
+            style={styles.actionButton}
+          />
+          <Button
+            label="들어갔어요"
+            variant="primary"
+            onPress={() => choose("allowed")}
+            style={styles.actionButton}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: Spacing.four,
+  },
+  backdrop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(34, 34, 34, 0.45)",
+  },
+  card: {
+    gap: Spacing.five,
+    padding: Spacing.four,
+    borderRadius: Radius.large,
+    backgroundColor: Palette.white,
+  },
+  closeButton: {
+    position: "absolute",
+    top: Spacing.three,
+    right: Spacing.three,
+    zIndex: 1,
+  },
+  heading: {
+    alignItems: "center",
+    gap: Spacing.three,
+    paddingTop: Spacing.three,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: Spacing.two,
+  },
+  actionButton: {
+    flex: 1,
+  },
+});

--- a/src/app/store/[placeId]/index.tsx
+++ b/src/app/store/[placeId]/index.tsx
@@ -52,7 +52,7 @@ export default function StoreDetailScreen() {
 
   const goWrite = () =>
     router.push({
-      pathname: "/review/[placeId]/receipt",
+      pathname: "/review/[placeId]/result",
       params: { placeId: place.id },
     });
 

--- a/src/components/review/alternative-place-card.tsx
+++ b/src/components/review/alternative-place-card.tsx
@@ -1,0 +1,68 @@
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { CATEGORY_LABEL } from "@/constants/category";
+import { SIZE_LABEL, STATUS_LABEL } from "@/constants/status";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import type { Place, SizeKey } from "@/types/place";
+
+export function AlternativePlaceCard({
+  place,
+  size,
+  onPress,
+}: {
+  place: Place;
+  size: SizeKey;
+  onPress: (placeId: string) => void;
+}) {
+  return (
+    <Pressable
+      onPress={() => onPress(place.id)}
+      accessibilityRole="button"
+      accessibilityLabel={`${place.name} 상세 보기`}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <ThemedText type="subtitle03" color={Palette.gray[700]}>
+        {place.name}
+      </ThemedText>
+      <ThemedText type="label05" color={Palette.gray[400]}>
+        {place.location}
+      </ThemedText>
+      <View style={styles.metaRow}>
+        <ThemedText type="label04" color={Palette.gray[500]}>
+          {CATEGORY_LABEL[place.category]}
+        </ThemedText>
+        <ThemedText type="label04" color={Palette.gray[300]}>
+          ·
+        </ThemedText>
+        <ThemedText type="label04" color={Palette.gray[500]}>
+          {SIZE_LABEL[size]}
+        </ThemedText>
+        <ThemedText type="subtitle04" color={Palette.status.allowed[300]}>
+          {STATUS_LABEL.allowed}
+        </ThemedText>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 6,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    borderRadius: Radius.medium,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    backgroundColor: Palette.white,
+  },
+  pressed: {
+    backgroundColor: Palette.background.subtle,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.one,
+    marginTop: Spacing.half,
+  },
+});

--- a/src/components/review/camera-capture.tsx
+++ b/src/components/review/camera-capture.tsx
@@ -32,13 +32,20 @@ export function CameraCapture({
   const capture = async () => {
     if (!permission?.granted) {
       const next = await requestPermission();
-      if (!next.granted) {
+      // 권한 거부 시엔 진행하지 않고 화면에 머문다.
+      // (에뮬레이터·데모용 폴백은 개발 빌드에서만)
+      if (!next.granted && __DEV__) {
         onCapture(fallbackUri);
       }
       return;
     }
     const shot = await cameraRef.current?.takePictureAsync({ quality: 0.7 });
-    onCapture(shot?.uri ?? fallbackUri);
+    // 촬영 실패로 uri가 없으면 진행하지 않는다(개발 빌드만 폴백).
+    if (shot?.uri) {
+      onCapture(shot.uri);
+    } else if (__DEV__) {
+      onCapture(fallbackUri);
+    }
   };
 
   return (

--- a/src/components/review/camera-capture.tsx
+++ b/src/components/review/camera-capture.tsx
@@ -1,0 +1,204 @@
+import { useRef, useState, type ReactNode } from "react";
+
+import { CameraView, useCameraPermissions } from "expo-camera";
+import { ArrowLeft, SwitchCamera } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+
+/** 인앱 카메라 뷰파인더(사진·영수증 공유). 촬영하면 uri를 onCapture로 넘긴다. */
+export function CameraCapture({
+  title,
+  hint,
+  fallbackUri,
+  onCapture,
+  onBack,
+  overlay,
+}: {
+  title: string;
+  hint?: string;
+  fallbackUri: string;
+  onCapture: (uri: string) => void;
+  onBack: () => void;
+  overlay?: ReactNode;
+}) {
+  const insets = useSafeAreaInsets();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [facing, setFacing] = useState<"back" | "front">("back");
+  const cameraRef = useRef<CameraView>(null);
+
+  const capture = async () => {
+    if (!permission?.granted) {
+      const next = await requestPermission();
+      if (!next.granted) {
+        onCapture(fallbackUri);
+      }
+      return;
+    }
+    const shot = await cameraRef.current?.takePictureAsync({ quality: 0.7 });
+    onCapture(shot?.uri ?? fallbackUri);
+  };
+
+  return (
+    <View style={styles.root}>
+      {permission?.granted ? (
+        <CameraView
+          ref={cameraRef}
+          style={StyleSheet.absoluteFill}
+          facing={facing}
+        />
+      ) : (
+        <View style={styles.fallback} />
+      )}
+
+      <View style={[styles.topBar, { paddingTop: insets.top + Spacing.two }]}>
+        <View style={styles.topRow}>
+          <Pressable
+            onPress={onBack}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="뒤로가기"
+          >
+            <ArrowLeft size={22} color={Palette.white} />
+          </Pressable>
+          <ThemedText type="subtitle03" color={Palette.white}>
+            {title}
+          </ThemedText>
+          <View style={styles.topSpacer} />
+        </View>
+
+        {hint ? (
+          <View style={styles.toast}>
+            <ThemedText
+              type="label04"
+              color={Palette.white}
+              style={styles.toastText}
+            >
+              {hint}
+            </ThemedText>
+          </View>
+        ) : null}
+
+        {overlay}
+      </View>
+
+      {!permission?.granted ? (
+        <View style={styles.permissionHint}>
+          <ThemedText type="label04" color={Palette.white}>
+            카메라 권한이 필요해요
+          </ThemedText>
+        </View>
+      ) : null}
+
+      <View
+        style={[styles.bar, { paddingBottom: insets.bottom + Spacing.four }]}
+      >
+        <ThemedText type="label05" color="rgba(255,255,255,0.4)">
+          갤러리 없음
+        </ThemedText>
+
+        <Pressable
+          onPress={capture}
+          accessibilityRole="button"
+          accessibilityLabel="촬영"
+          style={styles.shutterOuter}
+        >
+          <View style={styles.shutterInner} />
+        </Pressable>
+
+        <Pressable
+          onPress={() =>
+            setFacing((prev) => (prev === "back" ? "front" : "back"))
+          }
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="카메라 전환"
+          style={styles.switchButton}
+        >
+          <SwitchCamera size={22} color={Palette.white} />
+          <ThemedText type="label05" color={Palette.white}>
+            전환
+          </ThemedText>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.black,
+  },
+  fallback: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "#1A1A1A",
+  },
+  topBar: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 2,
+    gap: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    paddingBottom: Spacing.three,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  topSpacer: {
+    width: 22,
+  },
+  toast: {
+    padding: Spacing.three,
+    borderRadius: Radius.medium,
+    backgroundColor: "rgba(34, 34, 34, 0.55)",
+  },
+  toastText: {
+    textAlign: "center",
+  },
+  permissionHint: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  bar: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.five,
+    paddingTop: Spacing.four,
+  },
+  shutterOuter: {
+    width: 72,
+    height: 72,
+    borderRadius: Radius.pill,
+    borderWidth: 4,
+    borderColor: Palette.white,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  shutterInner: {
+    width: 56,
+    height: 56,
+    borderRadius: Radius.pill,
+    backgroundColor: Palette.white,
+  },
+  switchButton: {
+    alignItems: "center",
+    gap: Spacing.half,
+  },
+});

--- a/src/components/review/review-header-title.tsx
+++ b/src/components/review/review-header-title.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Spacing } from "@/constants/theme";
+
+/** 리뷰 플로우 헤더 2줄 타이틀(영수증·입력 공유). `headerTitle`에 넘겨 쓴다. */
+export function ReviewHeaderTitle({ placeName }: { placeName: string }) {
+  return (
+    <View style={styles.wrap}>
+      <ThemedText type="subtitle02" color={Palette.gray[700]}>
+        리뷰 작성하기
+      </ThemedText>
+      <ThemedText type="label06" color={Palette.gray[400]}>
+        {placeName}
+      </ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    alignItems: "center",
+    gap: Spacing.half,
+  },
+});

--- a/src/components/ui/text-field.tsx
+++ b/src/components/ui/text-field.tsx
@@ -20,6 +20,7 @@ export type TextFieldProps = TextInputProps & {
   error?: string;
   containerStyle?: StyleProp<ViewStyle>;
   rightAccessory?: ReactNode;
+  focusColor?: string;
   ref?: Ref<TextInput>;
 };
 
@@ -28,6 +29,7 @@ export function TextField({
   error,
   containerStyle,
   rightAccessory,
+  focusColor = Palette.black,
   style,
   onFocus,
   onBlur,
@@ -39,7 +41,7 @@ export function TextField({
   const borderColor = error
     ? ERROR_COLOR
     : focused
-      ? Palette.black
+      ? focusColor
       : Palette.border.default;
 
   const input = (

--- a/src/mocks/places.ts
+++ b/src/mocks/places.ts
@@ -1,4 +1,4 @@
-import type { Place } from "@/types/place";
+import type { Place, SizeKey } from "@/types/place";
 
 /**
  * 백엔드 API가 나오기 전까지 화면 개발용으로 쓰는 목 데이터.
@@ -175,7 +175,50 @@ export const MOCK_PLACES: Place[] = [
     reviewCount: 31,
     lastVerifiedAt: "2026-05-08T13:50:00Z",
   },
+  {
+    id: "p-016",
+    name: "멍카페 성수",
+    category: "cafe",
+    location: "서울 성동구 아차산로 7",
+    latitude: 37.5468,
+    longitude: 127.0409,
+    sizeStatus: { smallMedium: "allowed", large: "allowed" },
+    reviewCount: 58,
+    lastVerifiedAt: "2026-08-11T05:35:00Z",
+  },
+  {
+    id: "p-017",
+    name: "서울숲 로스터리",
+    category: "cafe",
+    location: "서울 성동구 왕십리로 83",
+    latitude: 37.5433,
+    longitude: 127.0348,
+    sizeStatus: { smallMedium: "allowed", large: "allowed" },
+    reviewCount: 45,
+    lastVerifiedAt: "2026-08-07T09:00:00Z",
+  },
 ];
+
+/**
+ * 거절 완료(S-12) 대안 카드. 실제로는 PostGIS 반경+상태 조인이지만 목에선
+ * 업종·상태 필터만 쓴다. 후보 0개 가능 — 호출부에서 폴백 처리.
+ */
+export function getAlternativePlaces(
+  placeId: string,
+  size: SizeKey,
+  limit = 3,
+): Place[] {
+  const origin = MOCK_PLACES.find((place) => place.id === placeId);
+  if (!origin) {
+    return [];
+  }
+  return MOCK_PLACES.filter(
+    (place) =>
+      place.id !== origin.id &&
+      place.category === origin.category &&
+      place.sizeStatus[size] === "allowed",
+  ).slice(0, limit);
+}
 
 /**
  * [DEV 전용] 영어 검색 키워드. 에뮬레이터에 한글 자판이 없어도 영어로
@@ -198,4 +241,6 @@ export const MOCK_PLACE_KEYWORDS: Record<string, string> = {
   "p-013": "seoul forest wetland park",
   "p-014": "bakery walk cafe",
   "p-015": "seongsu noodle",
+  "p-016": "mung cafe seongsu",
+  "p-017": "seoul forest roastery",
 };

--- a/src/mocks/receipt.ts
+++ b/src/mocks/receipt.ts
@@ -1,0 +1,60 @@
+import type { Place } from "@/types/place";
+
+/**
+ * 영수증 OCR 인증(S-06)의 목 판정. 실제로는 `POST /reviews/receipt-verify`가
+ * 상호명 유사도로 판정한다. 응답 형태는 `ReceiptVerifyResult`에 맞췄다.
+ * 실연동 시 이 파일만 교체. `outcome`은 세 분기를 강제하기 위한 목 전용 인자다.
+ */
+
+export type ReceiptOutcome = "verified" | "mismatch" | "unreadable";
+
+/** `POST /reviews/receipt-verify` 응답(프론트 사용 형태). */
+export interface ReceiptVerifyResult {
+  verified: boolean;
+  /** 통과 시 null, 실패 시 사유 코드("NAME_MISMATCH" 등). */
+  reason: string | null;
+  /** OCR로 읽은 상호명. 판독 실패 시 null. */
+  matchedName: string | null;
+  /** 0.0 ~ 1.0 */
+  similarity: number;
+  /** 통과 시에만 발급(30분 만료). 실패 시 null. */
+  receiptToken: string | null;
+}
+
+function nearbyWrongName(place: Place): string {
+  const base = place.name.split(" ")[0] ?? place.name;
+  return `${base} 베이커리`;
+}
+
+export function mockVerifyReceipt(
+  place: Place,
+  outcome: ReceiptOutcome = "verified",
+): ReceiptVerifyResult {
+  switch (outcome) {
+    case "mismatch":
+      return {
+        verified: false,
+        reason: "NAME_MISMATCH",
+        matchedName: nearbyWrongName(place),
+        similarity: 0.31,
+        receiptToken: null,
+      };
+    case "unreadable":
+      return {
+        verified: false,
+        reason: "OCR_FAILED",
+        matchedName: null,
+        similarity: 0,
+        receiptToken: null,
+      };
+    case "verified":
+    default:
+      return {
+        verified: true,
+        reason: null,
+        matchedName: place.name,
+        similarity: 0.97,
+        receiptToken: `mock-receipt-${place.id}`,
+      };
+  }
+}

--- a/src/stores/review-draft.ts
+++ b/src/stores/review-draft.ts
@@ -1,0 +1,95 @@
+import { create } from "zustand";
+
+import type { SizeKey } from "@/types/place";
+
+/**
+ * 리뷰 작성 플로우의 화면 간 공유 드래프트(zustand). 서버 전송은 아직 없음(UI 전용).
+ * 등록 시 이 값들이 `POST /reviews`(data)의
+ * dog_allowed·dog_size·tag_ids·content·receipt_token에 매핑된다.
+ */
+
+/** `dog_allowed`(true=들어갔어요 / false=거절당했어요)와 1:1. */
+export type ReviewResult = "allowed" | "denied";
+
+interface ReceiptDraft {
+  verified: boolean;
+  imageUri: string | null;
+  matchedName: string | null;
+  /** `POST /reviews/receipt-verify` 통과 시 발급되는 토큰. */
+  token: string | null;
+}
+
+interface ReviewDraftState {
+  placeId: string | null;
+  result: ReviewResult | null;
+  receipt: ReceiptDraft;
+  photoUri: string | null;
+  size: SizeKey | null;
+  tags: string[];
+  content: string;
+
+  begin: (placeId: string) => void;
+  /** 결과 변경 시 영수증·사진 초기화(재입력 필요). */
+  setResult: (result: ReviewResult) => void;
+  setReceipt: (patch: Partial<ReceiptDraft>) => void;
+  resetReceipt: () => void;
+  setPhotoUri: (uri: string | null) => void;
+  setSize: (size: SizeKey) => void;
+  toggleTag: (tag: string) => void;
+  setContent: (content: string) => void;
+  reset: () => void;
+}
+
+const EMPTY_RECEIPT: ReceiptDraft = {
+  verified: false,
+  imageUri: null,
+  matchedName: null,
+  token: null,
+};
+
+const INITIAL: Pick<
+  ReviewDraftState,
+  "placeId" | "result" | "receipt" | "photoUri" | "size" | "tags" | "content"
+> = {
+  placeId: null,
+  result: null,
+  receipt: EMPTY_RECEIPT,
+  photoUri: null,
+  size: null,
+  tags: [],
+  content: "",
+};
+
+export const useReviewDraft = create<ReviewDraftState>((set) => ({
+  ...INITIAL,
+
+  begin: (placeId) => set({ ...INITIAL, placeId }),
+
+  setResult: (result) =>
+    set((state) => {
+      if (state.result === result) {
+        return { result };
+      }
+      return { result, receipt: EMPTY_RECEIPT, photoUri: null };
+    }),
+
+  setReceipt: (patch) =>
+    set((state) => ({ receipt: { ...state.receipt, ...patch } })),
+
+  resetReceipt: () => set({ receipt: EMPTY_RECEIPT }),
+
+  setPhotoUri: (photoUri) => set({ photoUri }),
+
+  setSize: (size) => set({ size }),
+
+  toggleTag: (tag) =>
+    set((state) => ({
+      tags: state.tags.includes(tag)
+        ? state.tags.filter((item) => item !== tag)
+        : [...state.tags, tag],
+    })),
+
+  setContent: (content) => set({ content }),
+
+  reset: () => set({ ...INITIAL }),
+}));


### PR DESCRIPTION
## 🎯 작업 내용

리뷰 작성 플로우(플로우 A)의 화면 UI를 구현했습니다. 

```
[S-18 결과선택 모달]
  ├─ 들어갔어요 → [S-06 영수증] → [S-07 사진] → [S-08 입력] → [S-09 완료+스탬프]
  └─ 거절당했어요 ───────────────────────→ [S-08 입력] → [S-12 완료, 스탬프 없음]
```

**주요 설계 결정**

- **상태 전달**: `zustand` 드래프트 스토어(`stores/review-draft.ts`)로 통일. `placeId`만 라우트 파라미터로 흐르고 나머지(결과·영수증 인증·사진·크기·태그·내용)는 스토어에서 관리.
- **S-18 결과선택**: 상세 위에 뜨는 작은 모달 → `transparentModal` 라우트(`review/[placeId]/result`)로 구현해 상세가 뒤에 비치고 뒤로가기 재진입이 자연스럽게 동작.
- **카메라**: 영수증·사진 모두 `expo-camera` 인앱 뷰파인더 공용 컴포넌트(`CameraCapture`) 사용, 갤러리 업로드 없음.

## 📝 변경 사항

**상태 · 목데이터**

- `src/stores/review-draft.ts` — 리뷰 작성 드래프트 스토어(zustand). 화면 간 결과·영수증 인증·사진·크기·태그·내용 공유
- `src/mocks/receipt.ts` — 영수증 OCR 목 판정(`POST /reviews/receipt-verify` 응답 `ReceiptVerifyResult` 형태, 실연동 시 교체)
- `src/mocks/places.ts` — `getAlternativePlaces()`(같은 업종·해당 크기 `가능` 최대 3개) + 대안용 카페 목데이터 추가

**공용 컴포넌트**

- `src/components/review/camera-capture.tsx` — 인앱 카메라 뷰파인더(영수증·사진 공용, `expo-camera`, 갤러리 없음)
- `src/components/review/review-header-title.tsx` — 리뷰 플로우 2줄 헤더("리뷰 작성하기" + 가게명)
- `src/components/review/alternative-place-card.tsx` — 거절 완료 대안 장소 카드(가게명·도로명주소·크기 상태)
- `src/components/ui/text-field.tsx` — 포커스 테두리 색 `focusColor` prop 추가

**리뷰 플로우 화면**

- `src/app/review/[placeId]/result.tsx` — S-18 결과 선택(상세 위 작은 모달, `transparentModal` 라우트)
- `src/app/review/[placeId]/receipt.tsx` — S-06 영수증(인앱 카메라 → OCR 목 판정, 불일치·판독실패는 카메라 위 모달)
- `src/app/review/[placeId]/photo.tsx` — S-07 반려견 사진(인앱 카메라 → 미리보기 → `[다음]`/`[다시 찍기]`)
- `src/app/review/[placeId]/form.tsx` — S-08 입력(들어갔어요/거절 분기, 크기 칩·해시태그·자유 텍스트 10~50자, 거절 경고)
- `src/app/review/[placeId]/done.tsx` — S-09/S-12 완료(들어갔어요=스탬프 연출 / 거절=대안 카드·0개 폴백)

**라우트 · 진입점**

- `src/app/_layout.tsx` — 리뷰 라우트 등록(result 투명 모달, 헤더 옵션)
- `src/app/store/[placeId]/index.tsx` — 가게 상세 `[리뷰 쓰기]` → S-18 결과 선택 진입으로 연결

## 🔗 관련 이슈

- Closes #15

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 네이티브 설정 변경 없음 — 기존 `expo-camera`·`expo-image-picker` 플러그인 설정 그대로 사용(신규 권한/의존성 추가 없음).

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android (에뮬레이터에서 전 화면·분기 확인)

## 📸 스크린샷 / 화면 녹화 (UI 작업의 경우 필수)

> 각 셀의 `파일명`을 해당 스크린샷으로 교체(드래그&드롭)해 주세요.

### 공통 진입 — 결과 선택 (S-18)
| 결과 선택 모달|
| :--: |
| <img width="540" height="1200" alt="S18-result-modal" src="https://github.com/user-attachments/assets/488c0fb0-7d59-448b-8511-962fbf6b3a5d" /> |

### ✅ 들어갔어요 흐름

| 영수증 촬영 (S-06) | 인증 완료 (S-06) | 반려견 사진 (S-07) | 사진 미리보기 (S-07) |
| :--: | :--: | :--: | :--: |
| <img width="1080" height="2400" alt="S06-receipt-camera" src="https://github.com/user-attachments/assets/a45bf4e8-293a-4828-a6bf-85b87dc97cdd" /> | <img width="1080" height="2400" alt="S06-verified" src="https://github.com/user-attachments/assets/ef297105-56ea-4b9f-a546-9ecdf1966686" /> | <img width="1080" height="2400" alt="S07-photo-camera" src="https://github.com/user-attachments/assets/e8ffb4d6-733e-4d51-8440-06453e1a48ba" /> | <img width="1080" height="2400" alt="S07-photo-preview" src="https://github.com/user-attachments/assets/916b36e6-d7d4-4a88-ada6-3901e64a9c6f" /> |

| 리뷰 입력 (S-08) | 완료 — 스탬프 획득 (S-09) |
| :--: | :--: |
| <img width="1080" height="2400" alt="S08-form-allowed-top" src="https://github.com/user-attachments/assets/6c92d0e6-d4b8-4cd4-b80b-11bc2a6ca3b9" /><br><img width="1080" height="2400" alt="S08-form-allowed-bottom" src="https://github.com/user-attachments/assets/a2402205-eeb6-4bba-a4dd-f3f5f5f9fabd" /> | <img width="1080" height="2400" alt="S09-done-allowed" src="https://github.com/user-attachments/assets/09997ab9-7f4a-43c5-a899-538929806dc9" /> |

**영수증 실패 분기 (S-06)**

| 상호명 불일치 | 판독 실패 |
| :--: | :--: |
| <img width="1080" height="2400" alt="S06-mismatch-modal" src="https://github.com/user-attachments/assets/de1ceca9-a658-4151-b817-5f2403145660" /> |  <img width="1080" height="2400" alt="S06-unreadable-modal" src="https://github.com/user-attachments/assets/f329b352-1b79-402a-a51b-61a6c28b4a04" /> |

### ❌ 거절 흐름

| 리뷰 입력 (S-08) | 완료 — 대안 추천 (S-12) |
| :--: | :--: |
| <img width="1080" height="2400" alt="S08-form-denied" src="https://github.com/user-attachments/assets/ff09a0c6-3be0-4f02-936f-460e1b4ba6c3" /> | <img width="1080" height="2400" alt="S12-done-denied" src="https://github.com/user-attachments/assets/a3eeb7e0-179a-4e30-9cbf-bf3a034792b2" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 리뷰 결과 선택부터 영수증 인증, 반려견 사진 촬영, 리뷰 작성 및 완료까지의 흐름을 추가했습니다.
  - 영수증 판독 결과에 따른 재촬영·매장 재선택을 지원합니다.
  - 사진 미리보기, 재촬영, 해시태그 선택, 글자 수 표시 및 입력 검증을 제공합니다.
  - 리뷰 완료 후 스탬프 화면 또는 대안 장소 추천을 표시합니다.

- **개선 사항**
  - 카메라 권한 안내와 촬영 실패 시 대체 이미지를 지원합니다.
  - 리뷰 단계별 헤더, 모달 전환 애니메이션 및 화면 디자인을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->