### PR TITLE
[FEAT] 저장·마이 화면 UI 구현  

### DIFF
--- a/src/app/(main)/my.tsx
+++ b/src/app/(main)/my.tsx
@@ -1,5 +1,109 @@
-import { ScreenStub } from "@/components/screen-stub";
+import { useRouter } from "expo-router";
+import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Passport } from "@/components/my/passport";
+import { ProfileSummaryCard } from "@/components/my/profile-summary-card";
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Spacing } from "@/constants/theme";
+import { MOCK_PASSPORT, MOCK_USER } from "@/mocks/user";
+import type { PassportStamp } from "@/types/user";
 
 export default function MyScreen() {
-  return <ScreenStub name="마이" />;
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const openReviews = () => router.push("/my/reviews");
+
+  const openStamp = (stamp: PassportStamp) =>
+    router.push({
+      pathname: "/my/stamp/[stampId]",
+      params: { stampId: stamp.id },
+    });
+
+  const logout = () =>
+    Alert.alert("로그아웃", "로그아웃할까요?", [
+      { text: "취소", style: "cancel" },
+      {
+        text: "로그아웃",
+        style: "destructive",
+        onPress: () => router.replace("/login"),
+      },
+    ]);
+
+  const deleteAccount = () =>
+    Alert.alert(
+      "회원 탈퇴",
+      "정말 탈퇴할까요?\n모은 도장과 리뷰가 모두 사라져요.",
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "탈퇴",
+          style: "destructive",
+          onPress: () => router.replace("/login"),
+        },
+      ],
+    );
+
+  return (
+    <ScrollView
+      style={styles.root}
+      contentContainerStyle={[
+        styles.content,
+        { paddingTop: insets.top + Spacing.three },
+      ]}
+      showsVerticalScrollIndicator={false}
+    >
+      <ProfileSummaryCard
+        user={MOCK_USER}
+        onPressReviews={openReviews}
+        onLogout={logout}
+      />
+
+      <View style={styles.passportSection}>
+        <ThemedText type="subtitle02" color={Palette.gray[700]}>
+          나의 여권
+        </ThemedText>
+        <Passport stamps={MOCK_PASSPORT} onSelectStamp={openStamp} />
+      </View>
+
+      <Pressable
+        onPress={deleteAccount}
+        hitSlop={8}
+        accessibilityRole="button"
+        style={styles.deleteAccount}
+      >
+        <ThemedText
+          type="label05"
+          color={Palette.gray[400]}
+          style={styles.deleteAccountText}
+        >
+          회원 탈퇴
+        </ThemedText>
+      </Pressable>
+    </ScrollView>
+  );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  content: {
+    gap: Spacing.four,
+    paddingHorizontal: Spacing.four,
+    paddingBottom: Spacing.five,
+  },
+  passportSection: {
+    gap: Spacing.three,
+  },
+  deleteAccount: {
+    alignSelf: "center",
+    paddingVertical: Spacing.two,
+    paddingHorizontal: Spacing.three,
+  },
+  deleteAccountText: {
+    textDecorationLine: "underline",
+  },
+});

--- a/src/app/(main)/saved.tsx
+++ b/src/app/(main)/saved.tsx
@@ -1,5 +1,235 @@
-import { ScreenStub } from "@/components/screen-stub";
+import { useState } from "react";
+
+import { useRouter } from "expo-router";
+import { MapPin, Route, Trash2 } from "lucide-react-native";
+import {
+  Dimensions,
+  FlatList,
+  Modal,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { SavedCourseRow } from "@/components/saved/saved-course-row";
+import {
+  SavedPlaceRow,
+  type MenuAnchor,
+} from "@/components/saved/saved-place-row";
+import { ThemedText } from "@/components/themed-text";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { MOCK_SAVED_COURSES, MOCK_SAVED_PLACES } from "@/mocks/saved";
+import type { SavedCoursePreview } from "@/types/course";
+import type { Place } from "@/types/place";
+
+type Segment = "place" | "course";
+
+type ActiveMenu = { type: Segment; id: string; anchor: MenuAnchor };
+
+const SEGMENTS = [
+  { value: "place" as const, label: "장소", Icon: MapPin },
+  { value: "course" as const, label: "코스", Icon: Route },
+];
+
+const SCREEN_WIDTH = Dimensions.get("window").width;
 
 export default function SavedScreen() {
-  return <ScreenStub name="저장" />;
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const [segment, setSegment] = useState<Segment>("place");
+  const [places, setPlaces] = useState<Place[]>(MOCK_SAVED_PLACES);
+  const [courses, setCourses] =
+    useState<SavedCoursePreview[]>(MOCK_SAVED_COURSES);
+  const [menu, setMenu] = useState<ActiveMenu | null>(null);
+
+  const goMap = () => router.navigate("/map");
+
+  const openPlace = (place: Place) =>
+    router.push({
+      pathname: "/store/[placeId]",
+      params: { placeId: place.id },
+    });
+
+  const openCourse = (course: SavedCoursePreview) =>
+    router.push({
+      pathname: "/recommend/result",
+      params: { courseId: course.id },
+    });
+
+  const deleteActive = () => {
+    if (!menu) {
+      return;
+    }
+    if (menu.type === "place") {
+      setPlaces((prev) => prev.filter((item) => item.id !== menu.id));
+    } else {
+      setCourses((prev) => prev.filter((item) => item.id !== menu.id));
+    }
+    setMenu(null);
+  };
+
+  const renameCourse = (course: SavedCoursePreview, title: string) =>
+    setCourses((prev) =>
+      prev.map((item) => (item.id === course.id ? { ...item, title } : item)),
+    );
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + Spacing.three }]}>
+      <View style={styles.header}>
+        <SegmentedControl
+          options={SEGMENTS}
+          value={segment}
+          onChange={setSegment}
+        />
+      </View>
+
+      {segment === "place" ? (
+        places.length > 0 ? (
+          <FlatList
+            data={places}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={styles.listContent}
+            ItemSeparatorComponent={Separator}
+            showsVerticalScrollIndicator={false}
+            renderItem={({ item }) => (
+              <SavedPlaceRow
+                place={item}
+                onPress={openPlace}
+                onMenu={(place, anchor) =>
+                  setMenu({ type: "place", id: place.id, anchor })
+                }
+              />
+            )}
+          />
+        ) : (
+          <EmptyState
+            message={
+              "저장한 장소가 없어요\n지도에서 마음에 드는 곳을 저장해보세요"
+            }
+            onAction={goMap}
+          />
+        )
+      ) : courses.length > 0 ? (
+        <FlatList
+          data={courses}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.listContent}
+          ItemSeparatorComponent={Separator}
+          showsVerticalScrollIndicator={false}
+          renderItem={({ item }) => (
+            <SavedCourseRow
+              course={item}
+              onPress={openCourse}
+              onRename={renameCourse}
+              onMenu={(course, anchor) =>
+                setMenu({ type: "course", id: course.id, anchor })
+              }
+            />
+          )}
+        />
+      ) : (
+        <EmptyState
+          message={
+            "저장한 코스가 없어요\n추천받기로 코스를 만들어 저장해보세요"
+          }
+          onAction={goMap}
+        />
+      )}
+
+      <Modal
+        visible={menu !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setMenu(null)}
+      >
+        <Pressable style={styles.menuBackdrop} onPress={() => setMenu(null)}>
+          {menu ? (
+            <View
+              style={[
+                styles.menu,
+                {
+                  top: menu.anchor.y + menu.anchor.height + Spacing.one,
+                  right: Math.max(
+                    Spacing.two,
+                    SCREEN_WIDTH - (menu.anchor.x + menu.anchor.width),
+                  ),
+                },
+              ]}
+            >
+              <Pressable
+                style={({ pressed }) => [
+                  styles.menuItem,
+                  pressed && styles.menuItemPressed,
+                ]}
+                onPress={deleteActive}
+                accessibilityRole="button"
+                accessibilityLabel="삭제"
+              >
+                <Trash2 size={16} color={Palette.error[300]} />
+                <ThemedText type="subtitle04" color={Palette.error[300]}>
+                  삭제
+                </ThemedText>
+              </Pressable>
+            </View>
+          ) : null}
+        </Pressable>
+      </Modal>
+    </View>
+  );
 }
+
+function Separator() {
+  return <View style={styles.separator} />;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  header: {
+    gap: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    paddingBottom: Spacing.three,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.one,
+    paddingBottom: Spacing.five,
+  },
+  separator: {
+    height: Spacing.three,
+  },
+  menuBackdrop: {
+    flex: 1,
+  },
+  menu: {
+    position: "absolute",
+    alignSelf: "flex-start",
+    borderRadius: Radius.medium,
+    backgroundColor: Palette.background.base,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 3,
+    elevation: 1,
+  },
+  menuItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.two,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: Radius.medium,
+  },
+  menuItemPressed: {
+    backgroundColor: Palette.background.subtle,
+  },
+});

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -84,6 +84,19 @@ export default function RootLayout() {
               name="recommend/result"
               options={{ headerShown: false }}
             />
+
+            <Stack.Screen
+              name="my/reviews"
+              options={{ title: "내가 쓴 리뷰" }}
+            />
+            <Stack.Screen
+              name="my/stamp/[stampId]"
+              options={{
+                headerShown: false,
+                presentation: "transparentModal",
+                animation: "fade",
+              }}
+            />
           </Stack>
         </ThemeProvider>
       </QueryClientProvider>

--- a/src/app/my/reviews.tsx
+++ b/src/app/my/reviews.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from "expo-router";
+import { FlatList, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { MyReviewItem } from "@/components/review/my-review-item";
+import { ThemedText } from "@/components/themed-text";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ScreenHeader } from "@/components/ui/screen-header";
+import { Palette, Spacing } from "@/constants/theme";
+import { MOCK_PLACES } from "@/mocks/places";
+import { getMyReviews } from "@/mocks/reviews";
+
+const PLACE_BY_ID = new Map(MOCK_PLACES.map((place) => [place.id, place]));
+
+export default function MyReviewsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const reviews = getMyReviews();
+
+  const openStore = (placeId: string) =>
+    router.push({ pathname: "/store/[placeId]", params: { placeId } });
+
+  return (
+    <View style={styles.root}>
+      <ScreenHeader title="내가 쓴 리뷰" />
+
+      {reviews.length > 0 ? (
+        <FlatList
+          data={reviews}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={{
+            paddingBottom: insets.bottom + Spacing.four,
+          }}
+          ItemSeparatorComponent={Separator}
+          showsVerticalScrollIndicator={false}
+          ListHeaderComponent={
+            <ThemedText
+              type="label05"
+              color={Palette.gray[400]}
+              style={styles.summary}
+            >
+              최신순 · {reviews.length}건
+            </ThemedText>
+          }
+          renderItem={({ item }) => {
+            const place = PLACE_BY_ID.get(item.placeId);
+            if (!place) {
+              return null;
+            }
+            return (
+              <MyReviewItem review={item} place={place} onPress={openStore} />
+            );
+          }}
+        />
+      ) : (
+        <EmptyState
+          message="아직 남긴 리뷰가 없어요"
+          onAction={() => router.navigate("/map")}
+        />
+      )}
+    </View>
+  );
+}
+
+function Separator() {
+  return <View style={styles.separator} />;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Palette.background.base,
+  },
+  summary: {
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+    paddingBottom: Spacing.two,
+  },
+  separator: {
+    height: 1,
+    marginHorizontal: Spacing.four,
+    backgroundColor: Palette.border.disabled,
+  },
+});

--- a/src/app/my/stamp/[stampId].tsx
+++ b/src/app/my/stamp/[stampId].tsx
@@ -1,0 +1,171 @@
+import { Image } from "expo-image";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { ChevronRight, PawPrint, X } from "lucide-react-native";
+import { Alert, Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import { getStamp } from "@/mocks/user";
+import { formatReviewDate } from "@/utils/date";
+
+// 이미지 저장은 네이티브 의존성(view-shot/media-library) 전이라 안내만 — 실제 저장은 범위 밖.
+export default function StampDetailScreen() {
+  const router = useRouter();
+  const { stampId } = useLocalSearchParams<{ stampId: string }>();
+  const stamp = getStamp(stampId);
+
+  const close = () => router.back();
+
+  const openStore = () => {
+    if (stamp) {
+      router.replace({
+        pathname: "/store/[placeId]",
+        params: { placeId: stamp.storeId },
+      });
+    }
+  };
+
+  const saveImage = () =>
+    Alert.alert("준비 중", "이미지 저장 기능은 곧 제공될 예정이에요.");
+
+  return (
+    <View style={styles.root}>
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <Pressable
+        style={styles.backdrop}
+        onPress={close}
+        accessibilityLabel="닫기"
+      />
+
+      <View style={styles.card}>
+        <Pressable
+          style={styles.closeButton}
+          onPress={close}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="닫기"
+        >
+          <X size={22} color={Palette.gray[500]} />
+        </Pressable>
+
+        {stamp ? (
+          <>
+            <View style={styles.imageWrap}>
+              {stamp.photoUrl ? (
+                <Image
+                  source={{ uri: stamp.photoUrl }}
+                  style={styles.image}
+                  contentFit="cover"
+                  transition={150}
+                  accessibilityLabel="당시 촬영한 반려견 원본 사진"
+                />
+              ) : (
+                <View style={styles.silhouette}>
+                  <PawPrint
+                    size={72}
+                    color={Palette.main[300]}
+                    strokeWidth={1.6}
+                  />
+                  <ThemedText type="label05" color={Palette.gray[400]}>
+                    원본 사진이 없어 발도장으로 남겼어요
+                  </ThemedText>
+                </View>
+              )}
+            </View>
+
+            <Pressable
+              style={styles.storeRow}
+              onPress={openStore}
+              hitSlop={6}
+              accessibilityRole="button"
+              accessibilityLabel={`${stamp.storeName} 상세 보기`}
+            >
+              <ThemedText type="subtitle02" color={Palette.gray[700]}>
+                {stamp.storeName}
+              </ThemedText>
+              <ChevronRight size={18} color={Palette.gray[500]} />
+            </Pressable>
+
+            <ThemedText type="label05" color={Palette.gray[400]}>
+              {formatReviewDate(stamp.createdAt)}
+            </ThemedText>
+
+            <Button
+              label="원본 이미지 저장하기"
+              variant="secondary"
+              onPress={saveImage}
+              style={styles.saveButton}
+            />
+          </>
+        ) : (
+          <ThemedText
+            type="label03"
+            color={Palette.gray[500]}
+            style={styles.notFound}
+          >
+            도장 정보를 찾을 수 없어요
+          </ThemedText>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: Spacing.four,
+  },
+  backdrop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  card: {
+    width: "100%",
+    maxWidth: 360,
+    gap: Spacing.three,
+    padding: Spacing.four,
+    borderRadius: Radius.large,
+    backgroundColor: Palette.background.base,
+  },
+  closeButton: {
+    alignSelf: "flex-end",
+  },
+  imageWrap: {
+    width: "100%",
+    aspectRatio: 1,
+    borderRadius: Radius.medium,
+    backgroundColor: Palette.background.subtle,
+    overflow: "hidden",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+  },
+  silhouette: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.two,
+  },
+  storeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.half,
+  },
+  saveButton: {
+    marginTop: Spacing.one,
+  },
+  notFound: {
+    textAlign: "center",
+    paddingVertical: Spacing.five,
+  },
+});

--- a/src/app/recommend/result.tsx
+++ b/src/app/recommend/result.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { Footprints } from "lucide-react-native";
 import { Modal, ScrollView, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -11,7 +12,11 @@ import { Button } from "@/components/ui/button";
 import { DURATION_LABEL, PURPOSE_LABEL } from "@/constants/course";
 import { SIZE_LABEL } from "@/constants/status";
 import { Palette, Radius, Spacing } from "@/constants/theme";
-import { MOCK_COURSE, MOCK_COURSE_FALLBACK } from "@/mocks/courses";
+import {
+  getCourseById,
+  MOCK_COURSE,
+  MOCK_COURSE_FALLBACK,
+} from "@/mocks/courses";
 import type { CourseDuration, CoursePurpose } from "@/types/course";
 import type { SizeKey } from "@/types/place";
 import { formatDistance, formatWalkTime } from "@/utils/format";
@@ -24,6 +29,8 @@ export default function RecommendResultScreen() {
     purposes?: string;
     duration?: string;
     variant?: string;
+    /** 저장 코스(S-15)에서 열 때 id 재사용 — 재계산 없이 같은 코스를 재현한다. */
+    courseId?: string;
   }>();
 
   const [saved, setSaved] = useState(false);
@@ -40,9 +47,15 @@ export default function RecommendResultScreen() {
     router.navigate("/saved");
   };
 
-  // 경로 API 실패·조건 완화 상태 확인용 폴백 코스(?variant=fallback).
-  const course =
-    params.variant === "fallback" ? MOCK_COURSE_FALLBACK : MOCK_COURSE;
+  // 저장 코스에서 열면 id로 재현하고, 아니면 폴백 확인용 variant(추천 플로우)로 고른다.
+  const course = params.courseId
+    ? getCourseById(params.courseId)
+    : params.variant === "fallback"
+      ? MOCK_COURSE_FALLBACK
+      : MOCK_COURSE;
+
+  // 저장 코스에서 들어온 경우 이미 저장된 상태 → 저장 버튼 없이 닫기만 노출.
+  const fromSaved = Boolean(params.courseId);
 
   const title = buildTitle(params, course);
 
@@ -71,25 +84,27 @@ export default function RecommendResultScreen() {
               {course.waypoints.length}지점 · 총{" "}
               {formatDistance(course.totalDistance)}
             </ThemedText>
-            <ThemedText type="label04" color={Palette.gray[500]}>
-              도보 약 {formatWalkTime(course.totalTime)}
-            </ThemedText>
+            <View style={styles.walkMeta}>
+              <Footprints size={14} color={Palette.gray[500]} strokeWidth={2} />
+              <ThemedText type="label04" color={Palette.gray[500]}>
+                도보 약 {formatWalkTime(course.totalTime)}
+              </ThemedText>
+            </View>
           </View>
         </View>
 
-        {course.relaxed ? (
-          <View style={styles.banner}>
-            <ThemedText type="label05" color={Palette.main[500]}>
-              조건에 딱 맞는 곳이 적어 조건을 조금 넓혔어요
-            </ThemedText>
-          </View>
-        ) : null}
-
-        {course.walkPath === null ? (
-          <View style={styles.noteRow}>
-            <ThemedText type="label06" color={Palette.gray[400]}>
-              경로를 불러오지 못해 지점을 직선으로 이었어요
-            </ThemedText>
+        {course.relaxed || course.walkPath === null ? (
+          <View style={styles.noticeBox}>
+            {course.relaxed ? (
+              <ThemedText type="subtitle05" color={Palette.main[500]}>
+                조건에 딱 맞는 곳이 적어 조건을 조금 넓혔어요
+              </ThemedText>
+            ) : null}
+            {course.walkPath === null ? (
+              <ThemedText type="label06" color={Palette.gray[400]}>
+                경로를 불러오지 못해 지점을 직선으로 이었어요
+              </ThemedText>
+            ) : null}
           </View>
         ) : null}
 
@@ -123,13 +138,15 @@ export default function RecommendResultScreen() {
             onPress={() => router.dismissAll()}
             style={styles.footerButton}
           />
-          <Button
-            label={saved ? "저장됨" : "코스 저장"}
-            variant="main"
-            disabled={saved}
-            onPress={save}
-            style={styles.footerButton}
-          />
+          {fromSaved ? null : (
+            <Button
+              label={saved ? "저장됨" : "코스 저장"}
+              variant="main"
+              disabled={saved}
+              onPress={save}
+              style={styles.footerButton}
+            />
+          )}
         </View>
       </View>
 
@@ -225,16 +242,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
   },
-  banner: {
+  walkMeta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.one,
+  },
+  noticeBox: {
     marginHorizontal: Spacing.four,
     marginBottom: Spacing.two,
     padding: Spacing.three,
+    gap: Spacing.one,
     borderRadius: Radius.medium,
     backgroundColor: "rgba(255, 154, 134, 0.12)",
-  },
-  noteRow: {
-    paddingHorizontal: Spacing.four,
-    paddingBottom: Spacing.two,
   },
   listDivider: {
     height: 1,

--- a/src/components/my/passport-book.tsx
+++ b/src/components/my/passport-book.tsx
@@ -1,0 +1,95 @@
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+
+/** 원본 펼친 책 일러스트의 좌표계. slot·크롭이 공유한다. */
+export const BOOK = { width: 380, height: 288 };
+
+/** side별 크롭 창(book 좌표). 두 창은 같은 크기라 프레임 비율이 일정하고 x만 좌/우로 옮긴다. */
+export const WINDOWS = {
+  left: { x: 16, y: 24, w: 189, h: 236 },
+  right: { x: 175, y: 24, w: 189, h: 236 },
+} as const;
+
+export const WINDOW_ASPECT = WINDOWS.left.w / WINDOWS.left.h;
+
+// Svg viewBox를 크롭 창으로 잡아 왜곡 없이 한쪽 페이지만 확대해 보여준다.
+export function PassportBook({
+  width,
+  height,
+  side,
+}: {
+  width: number;
+  height: number;
+  side: "left" | "right";
+}) {
+  const w = WINDOWS[side];
+
+  return (
+    <Svg width={width} height={height} viewBox={`${w.x} ${w.y} ${w.w} ${w.h}`}>
+      <Defs>
+        <LinearGradient id="cover" x1="0" y1="0" x2="0" y2="1">
+          <Stop offset="0" stopColor="#37436E" />
+          <Stop offset="1" stopColor="#222B49" />
+        </LinearGradient>
+        <LinearGradient id="pageL" x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="0" stopColor="#FCFAF4" />
+          <Stop offset="0.78" stopColor="#F1ECE1" />
+          <Stop offset="1" stopColor="#E4DCCE" />
+        </LinearGradient>
+        <LinearGradient id="pageR" x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="0" stopColor="#E4DCCE" />
+          <Stop offset="0.22" stopColor="#F1ECE1" />
+          <Stop offset="1" stopColor="#FCFAF4" />
+        </LinearGradient>
+        <LinearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="0" stopColor="#2A3350" stopOpacity="0" />
+          <Stop offset="0.5" stopColor="#2A3350" stopOpacity="0.08" />
+          <Stop offset="1" stopColor="#2A3350" stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+
+      <Rect x="16" y="24" width="348" height="236" rx="17" fill="url(#cover)" />
+      <Rect
+        x="16"
+        y="24"
+        width="348"
+        height="236"
+        rx="17"
+        fill="none"
+        stroke="#FFFFFF"
+        strokeOpacity="0.1"
+        strokeWidth="1.5"
+      />
+
+      <Rect x="27" y="33" width="163" height="218" rx="8" fill="#D8D1C1" />
+      <Rect x="190" y="33" width="163" height="218" rx="8" fill="#D8D1C1" />
+      <Rect x="30" y="35" width="158" height="214" rx="7" fill="url(#pageL)" />
+      <Rect x="192" y="35" width="158" height="214" rx="7" fill="url(#pageR)" />
+
+      <Rect
+        x="40"
+        y="45"
+        width="138"
+        height="194"
+        rx="5"
+        fill="none"
+        stroke="#C6BEAC"
+        strokeOpacity="0.5"
+        strokeWidth="1"
+      />
+      <Rect
+        x="202"
+        y="45"
+        width="138"
+        height="194"
+        rx="5"
+        fill="none"
+        stroke="#C6BEAC"
+        strokeOpacity="0.5"
+        strokeWidth="1"
+      />
+
+      <Rect x="150" y="35" width="80" height="214" fill="url(#spine)" />
+      <Rect x="188" y="30" width="4" height="224" rx="2" fill="#20294A" />
+    </Svg>
+  );
+}

--- a/src/components/my/passport-slots.ts
+++ b/src/components/my/passport-slots.ts
@@ -1,0 +1,39 @@
+// 도장 슬롯 좌표는 원본 책(BOOK 380×288) 기준 — 렌더 시 크롭 창 기준으로 환산한다.
+export const LEFT_SLOTS: { x: number; y: number }[] = [
+  { x: 74, y: 78 },
+  { x: 128, y: 110 },
+  { x: 70, y: 150 },
+  { x: 126, y: 182 },
+  { x: 74, y: 214 },
+];
+
+export const RIGHT_SLOTS: { x: number; y: number }[] = [
+  { x: 250, y: 78 },
+  { x: 305, y: 110 },
+  { x: 246, y: 150 },
+  { x: 302, y: 182 },
+  { x: 250, y: 214 },
+];
+
+export function slotsFor(side: "left" | "right") {
+  return side === "left" ? LEFT_SLOTS : RIGHT_SLOTS;
+}
+
+export const STAMPS_PER_PAGE = 5;
+
+/** book 좌표 단위 지름(px는 크롭 스케일을 곱함). */
+const BASE_SIZE = 52;
+
+// id 해시로 크기·각도를 결정론적으로 — 리렌더마다 흔들리지 않게 Math.random 대신.
+export function stampJitter(id: string): { size: number; angle: number } {
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1) {
+    hash = (hash * 31 + id.charCodeAt(i)) & 0xffff;
+  }
+  const a = (hash % 100) / 100;
+  const b = ((hash >> 4) % 100) / 100;
+  return {
+    size: Math.round(BASE_SIZE + (a - 0.5) * 10),
+    angle: Math.round((b - 0.5) * 28),
+  };
+}

--- a/src/components/my/passport-stamp.tsx
+++ b/src/components/my/passport-stamp.tsx
@@ -1,0 +1,68 @@
+import { Image } from "expo-image";
+import { PawPrint } from "lucide-react-native";
+import { Pressable, StyleSheet } from "react-native";
+
+import { Palette, Radius } from "@/constants/theme";
+import type { PassportStamp } from "@/types/user";
+
+export function PassportStampView({
+  stamp,
+  size,
+  angle,
+  onPress,
+}: {
+  stamp: PassportStamp;
+  size: number;
+  angle: number;
+  onPress: (stamp: PassportStamp) => void;
+}) {
+  return (
+    <Pressable
+      onPress={() => onPress(stamp)}
+      accessibilityRole="button"
+      accessibilityLabel={`${stamp.storeName} 도장`}
+      style={({ pressed }) => [
+        styles.stamp,
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          transform: [{ rotate: `${angle}deg` }, { scale: pressed ? 0.94 : 1 }],
+        },
+      ]}
+    >
+      {stamp.stampUrl ? (
+        <Image
+          source={{ uri: stamp.stampUrl }}
+          style={styles.image}
+          contentFit="cover"
+          transition={120}
+          accessibilityLabel={`${stamp.storeName} 도장`}
+        />
+      ) : (
+        <PawPrint
+          size={size * 0.44}
+          color={Palette.main[500]}
+          strokeWidth={2}
+        />
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  stamp: {
+    position: "absolute",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 2,
+    borderColor: Palette.main[300],
+    backgroundColor: "rgba(255, 154, 134, 0.14)",
+    overflow: "hidden",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+    borderRadius: Radius.pill,
+  },
+});

--- a/src/components/my/passport.tsx
+++ b/src/components/my/passport.tsx
@@ -1,0 +1,237 @@
+import { useRef, useState } from "react";
+
+import { ChevronLeft, ChevronRight, PawPrint } from "lucide-react-native";
+import {
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import type { PassportStamp } from "@/types/user";
+
+import { PassportBook, WINDOWS } from "./passport-book";
+import { slotsFor, STAMPS_PER_PAGE, stampJitter } from "./passport-slots";
+import { PassportStampView } from "./passport-stamp";
+
+/** 스파인 쪽을 제외한 3면 안쪽 패딩(px). */
+const PAD = 12;
+
+function chunk(stamps: PassportStamp[]): PassportStamp[][] {
+  const pages: PassportStamp[][] = [];
+  for (let i = 0; i < stamps.length; i += STAMPS_PER_PAGE) {
+    pages.push(stamps.slice(i, i + STAMPS_PER_PAGE));
+  }
+  return pages;
+}
+
+export function Passport({
+  stamps,
+  onSelectStamp,
+}: {
+  stamps: PassportStamp[];
+  onSelectStamp: (stamp: PassportStamp) => void;
+}) {
+  const scrollRef = useRef<ScrollView>(null);
+  const [width, setWidth] = useState(0);
+  const [page, setPage] = useState(0);
+
+  // 책은 바깥/위/아래 3면에만 PAD만큼 줄이고, 스파인 쪽은 프레임에 붙인다.
+  const bookW = width > 0 ? width - PAD : 0;
+  const bookScale = bookW / WINDOWS.left.w;
+  const bookH = Math.round(WINDOWS.left.h * bookScale);
+  const boardHeight = bookH + PAD * 2;
+  const pages = chunk(stamps);
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    setWidth(event.nativeEvent.layout.width);
+  };
+
+  const onScrollEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (width > 0) {
+      setPage(Math.round(event.nativeEvent.contentOffset.x / width));
+    }
+  };
+
+  const goToPage = (next: number) => {
+    const clamped = Math.max(0, Math.min(pages.length - 1, next));
+    setPage(clamped);
+    scrollRef.current?.scrollTo({ x: clamped * width, animated: true });
+  };
+
+  const isEmpty = stamps.length === 0;
+
+  const renderPage = (pageStamps: PassportStamp[], side: "left" | "right") => {
+    const win = WINDOWS[side];
+    const slots = slotsFor(side);
+    // 왼쪽 페이지: 스파인이 오른쪽 → 왼쪽에 PAD, 오른쪽 flush. 오른쪽 페이지는 반대.
+    const bookLeft = side === "left" ? PAD : 0;
+    return (
+      <View
+        style={{
+          position: "absolute",
+          left: bookLeft,
+          top: PAD,
+          width: bookW,
+          height: bookH,
+        }}
+      >
+        <PassportBook width={bookW} height={bookH} side={side} />
+        {pageStamps.map((stamp, index) => {
+          const slot = slots[index];
+          const { size, angle } = stampJitter(stamp.id);
+          const px = size * bookScale;
+          return (
+            <View
+              key={stamp.id}
+              style={{
+                position: "absolute",
+                left: (slot.x - win.x) * bookScale - px / 2,
+                top: (slot.y - win.y) * bookScale - px / 2,
+              }}
+            >
+              <PassportStampView
+                stamp={stamp}
+                size={px}
+                angle={angle}
+                onPress={onSelectStamp}
+              />
+            </View>
+          );
+        })}
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.frame} onLayout={onLayout}>
+        {width === 0 ? (
+          <View style={{ height: 260 }} />
+        ) : isEmpty ? (
+          <View style={{ width, height: boardHeight }}>
+            {renderPage([], "left")}
+            <View style={styles.emptyOverlay} pointerEvents="none">
+              <PawPrint size={28} color={Palette.gray[300]} />
+              <ThemedText type="label04" color={Palette.gray[400]}>
+                아직 모은 도장이 없어요
+              </ThemedText>
+            </View>
+          </View>
+        ) : (
+          <ScrollView
+            ref={scrollRef}
+            horizontal
+            pagingEnabled
+            showsHorizontalScrollIndicator={false}
+            onMomentumScrollEnd={onScrollEnd}
+          >
+            {pages.map((pageStamps, pageIndex) => (
+              <View key={pageIndex} style={{ width, height: boardHeight }}>
+                {renderPage(pageStamps, pageIndex % 2 === 0 ? "left" : "right")}
+              </View>
+            ))}
+          </ScrollView>
+        )}
+      </View>
+
+      {!isEmpty && pages.length > 1 ? (
+        <View style={styles.nav}>
+          <NavArrow
+            Icon={ChevronLeft}
+            disabled={page === 0}
+            onPress={() => goToPage(page - 1)}
+            label="이전 페이지"
+          />
+          <ThemedText type="subtitle05" color={Palette.gray[500]}>
+            {page + 1} / {pages.length}
+          </ThemedText>
+          <NavArrow
+            Icon={ChevronRight}
+            disabled={page === pages.length - 1}
+            onPress={() => goToPage(page + 1)}
+            label="다음 페이지"
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function NavArrow({
+  Icon,
+  disabled,
+  onPress,
+  label,
+}: {
+  Icon: typeof ChevronLeft;
+  disabled: boolean;
+  onPress: () => void;
+  label: string;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      style={({ pressed }) => [
+        styles.arrow,
+        pressed && !disabled && styles.arrowPressed,
+      ]}
+    >
+      <Icon
+        size={20}
+        color={disabled ? Palette.gray[300] : Palette.gray[600]}
+        strokeWidth={2.2}
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: Spacing.three,
+  },
+  frame: {
+    borderRadius: Radius.large,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    backgroundColor: Palette.background.base,
+    overflow: "hidden",
+  },
+  emptyOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.two,
+  },
+  nav: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.four,
+  },
+  arrow: {
+    width: 36,
+    height: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: Palette.gray[100],
+  },
+  arrowPressed: {
+    backgroundColor: Palette.gray[200],
+  },
+});

--- a/src/components/my/profile-summary-card.tsx
+++ b/src/components/my/profile-summary-card.tsx
@@ -1,0 +1,114 @@
+import { ChevronRight, Dog } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import type { UserSummary } from "@/types/user";
+
+export function ProfileSummaryCard({
+  user,
+  onPressReviews,
+  onLogout,
+}: {
+  user: UserSummary;
+  onPressReviews: () => void;
+  onLogout: () => void;
+}) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.avatar}>
+          <Dog size={24} color={Palette.main[500]} />
+        </View>
+        <ThemedText
+          type="subtitle01"
+          color={Palette.gray[700]}
+          style={styles.name}
+        >
+          {user.nickname}
+        </ThemedText>
+        <Pressable onPress={onLogout} hitSlop={8} accessibilityRole="button">
+          <ThemedText type="label05" color={Palette.gray[400]}>
+            로그아웃
+          </ThemedText>
+        </Pressable>
+      </View>
+
+      <View style={styles.stats}>
+        <Pressable
+          style={styles.stat}
+          onPress={onPressReviews}
+          accessibilityRole="button"
+          accessibilityLabel="내가 쓴 리뷰 목록 보기"
+        >
+          <View style={styles.statLabelRow}>
+            <ThemedText type="label05" color={Palette.gray[500]}>
+              내가 쓴 리뷰
+            </ThemedText>
+            <ChevronRight size={14} color={Palette.gray[400]} />
+          </View>
+          <ThemedText type="head03" color={Palette.gray[700]}>
+            {user.reviewCount}
+          </ThemedText>
+        </Pressable>
+
+        <View style={styles.divider} />
+
+        <View style={styles.stat}>
+          <ThemedText type="label05" color={Palette.gray[500]}>
+            모은 도장
+          </ThemedText>
+          <ThemedText type="head03" color={Palette.gray[700]}>
+            {user.stampCount}
+          </ThemedText>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: Spacing.four,
+    padding: Spacing.four,
+    borderRadius: Radius.large,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    backgroundColor: Palette.background.base,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.three,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: "rgba(255, 154, 134, 0.16)",
+  },
+  name: {
+    flex: 1,
+  },
+  stats: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  stat: {
+    flex: 1,
+    gap: Spacing.two,
+  },
+  statLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.half,
+  },
+  divider: {
+    width: 1,
+    alignSelf: "stretch",
+    marginHorizontal: Spacing.three,
+    backgroundColor: Palette.border.disabled,
+  },
+});

--- a/src/components/review/my-review-item.tsx
+++ b/src/components/review/my-review-item.tsx
@@ -1,0 +1,85 @@
+import { Image } from "expo-image";
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ReviewResultBadge } from "@/components/review/review-result-badge";
+import { ThemedText } from "@/components/themed-text";
+import { CATEGORY_LABEL } from "@/constants/category";
+import { SIZE_LABEL } from "@/constants/status";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import type { Place } from "@/types/place";
+import type { Review } from "@/types/review";
+import { formatMonthDay } from "@/utils/date";
+
+export function MyReviewItem({
+  review,
+  place,
+  onPress,
+}: {
+  review: Review;
+  place: Place;
+  onPress: (placeId: string) => void;
+}) {
+  const thumbnail = review.thumbnailUrl ?? review.photoUrl;
+
+  return (
+    <Pressable
+      onPress={() => onPress(place.id)}
+      accessibilityRole="button"
+      style={({ pressed }) => [styles.item, pressed && styles.pressed]}
+    >
+      {thumbnail ? (
+        <Image
+          source={{ uri: thumbnail }}
+          style={styles.thumbnail}
+          contentFit="cover"
+          transition={150}
+          accessibilityLabel={`${place.name} 리뷰 사진`}
+        />
+      ) : null}
+
+      <View style={styles.content}>
+        <View style={styles.topRow}>
+          <ReviewResultBadge allowed={review.dogAllowed} />
+          <ThemedText type="label05" color={Palette.gray[400]}>
+            {formatMonthDay(review.createdAt)}
+          </ThemedText>
+        </View>
+
+        <ThemedText type="subtitle03" color={Palette.gray[700]}>
+          {place.name}
+        </ThemedText>
+        <ThemedText type="label05" color={Palette.gray[400]}>
+          {CATEGORY_LABEL[place.category]} · {SIZE_LABEL[review.dogSize]}
+        </ThemedText>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.three,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+  },
+  pressed: {
+    backgroundColor: Palette.background.subtle,
+  },
+  content: {
+    flex: 1,
+    gap: 6,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  thumbnail: {
+    width: 64,
+    height: 64,
+    borderRadius: Radius.medium,
+    backgroundColor: Palette.gray[100],
+  },
+});

--- a/src/components/saved/saved-course-row.tsx
+++ b/src/components/saved/saved-course-row.tsx
@@ -1,0 +1,183 @@
+import { useRef, useState } from "react";
+
+import { Check, MoreVertical, Pencil } from "lucide-react-native";
+import { Pressable, StyleSheet, TextInput, View } from "react-native";
+
+import type { MenuAnchor } from "@/components/saved/saved-place-row";
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Radius, Spacing, Typography } from "@/constants/theme";
+import type { SavedCoursePreview } from "@/types/course";
+import { formatDistance, formatWalkTime } from "@/utils/format";
+
+export function SavedCourseRow({
+  course,
+  onPress,
+  onRename,
+  onMenu,
+}: {
+  course: SavedCoursePreview;
+  onPress: (course: SavedCoursePreview) => void;
+  onRename: (course: SavedCoursePreview, title: string) => void;
+  onMenu: (course: SavedCoursePreview, anchor: MenuAnchor) => void;
+}) {
+  const menuRef = useRef<View>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(course.title);
+
+  const openMenu = () => {
+    menuRef.current?.measureInWindow((x, y, width, height) =>
+      onMenu(course, { x, y, width, height }),
+    );
+  };
+
+  const startEdit = () => {
+    setDraft(course.title);
+    setEditing(true);
+  };
+
+  const commit = () => {
+    const title = draft.trim();
+    if (title.length > 0 && title !== course.title) {
+      onRename(course, title);
+    }
+    setEditing(false);
+  };
+
+  return (
+    <Pressable
+      onPress={() => onPress(course)}
+      onLongPress={openMenu}
+      accessibilityRole="button"
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <View style={styles.body}>
+        <View style={styles.titleRow}>
+          {editing ? (
+            <>
+              <TextInput
+                value={draft}
+                onChangeText={setDraft}
+                autoFocus
+                maxLength={30}
+                returnKeyType="done"
+                selectTextOnFocus
+                onSubmitEditing={commit}
+                onBlur={commit}
+                style={styles.input}
+                accessibilityLabel="코스 이름 입력"
+              />
+              <Pressable
+                onPress={commit}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="이름 저장"
+                style={styles.editButton}
+              >
+                <Check size={16} color={Palette.main[500]} />
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <ThemedText
+                type="subtitle03"
+                color={Palette.gray[700]}
+                numberOfLines={1}
+                style={styles.title}
+              >
+                {course.title}
+              </ThemedText>
+              <Pressable
+                onPress={startEdit}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={`${course.title} 이름 수정`}
+                style={styles.editButton}
+              >
+                <Pencil size={15} color={Palette.gray[400]} />
+              </Pressable>
+            </>
+          )}
+        </View>
+
+        <ThemedText type="label05" color={Palette.gray[400]} numberOfLines={1}>
+          {course.storeNames.join(" · ")}
+        </ThemedText>
+
+        <View style={styles.metaLine}>
+          <ThemedText type="label05" color={Palette.gray[500]}>
+            {course.storeCount}지점{"   ·   "}총{" "}
+            {formatDistance(course.totalDistance)}
+            {"   ·   "}도보 약 {formatWalkTime(course.totalTime)}
+          </ThemedText>
+        </View>
+      </View>
+
+      <Pressable
+        ref={menuRef}
+        onPress={openMenu}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`${course.title} 더보기`}
+        style={styles.menuButton}
+      >
+        <MoreVertical size={20} color={Palette.gray[300]} strokeWidth={1.75} />
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: Spacing.two,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    borderRadius: Radius.medium,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    backgroundColor: Palette.background.base,
+  },
+  pressed: {
+    backgroundColor: Palette.background.subtle,
+  },
+  body: {
+    flex: 1,
+    gap: 6,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    // 표시/편집 모드에서 카드 높이가 변하지 않도록 제목 줄 높이를 고정한다.
+    height: 24,
+  },
+  title: {
+    flexShrink: 1,
+  },
+  input: {
+    flex: 1,
+    height: 24,
+    paddingVertical: 0,
+    paddingHorizontal: 0,
+    textAlignVertical: "center",
+    color: Palette.gray[700],
+    borderBottomWidth: 1,
+    borderBottomColor: Palette.main[400],
+    ...Typography.subtitle03,
+    includeFontPadding: false,
+    outlineWidth: 0,
+    outlineStyle: "none" as "solid",
+  },
+  editButton: {
+    padding: Spacing.half,
+  },
+  metaLine: {
+    marginTop: Spacing.half,
+  },
+  menuButton: {
+    marginTop: -Spacing.one,
+    marginRight: -Spacing.two,
+    padding: Spacing.one,
+  },
+});

--- a/src/components/saved/saved-place-row.tsx
+++ b/src/components/saved/saved-place-row.tsx
@@ -1,0 +1,115 @@
+import { useRef } from "react";
+
+import { MoreVertical } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { CATEGORY_LABEL } from "@/constants/category";
+import { STATUS_LABEL } from "@/constants/status";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+import type { Place, PlaceStatus } from "@/types/place";
+
+export type MenuAnchor = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const statusColor = (status: PlaceStatus) => Palette.status[status][300];
+
+export function SavedPlaceRow({
+  place,
+  onPress,
+  onMenu,
+}: {
+  place: Place;
+  onPress: (place: Place) => void;
+  onMenu: (place: Place, anchor: MenuAnchor) => void;
+}) {
+  const menuRef = useRef<View>(null);
+
+  const openMenu = () => {
+    menuRef.current?.measureInWindow((x, y, width, height) =>
+      onMenu(place, { x, y, width, height }),
+    );
+  };
+
+  return (
+    <Pressable
+      onPress={() => onPress(place)}
+      onLongPress={openMenu}
+      accessibilityRole="button"
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <View style={styles.body}>
+        <ThemedText type="subtitle03" color={Palette.gray[700]}>
+          {place.name}
+        </ThemedText>
+        <ThemedText type="label05" color={Palette.gray[400]}>
+          {CATEGORY_LABEL[place.category]} · {place.location}
+        </ThemedText>
+
+        <View style={styles.statusLine}>
+          <ThemedText type="label05" color={Palette.gray[500]}>
+            소·중형{" "}
+            <ThemedText
+              type="label05"
+              color={statusColor(place.sizeStatus.smallMedium)}
+            >
+              {STATUS_LABEL[place.sizeStatus.smallMedium]}
+            </ThemedText>
+            {"   ·   "}
+            대형{" "}
+            <ThemedText
+              type="label05"
+              color={statusColor(place.sizeStatus.large)}
+            >
+              {STATUS_LABEL[place.sizeStatus.large]}
+            </ThemedText>
+          </ThemedText>
+        </View>
+      </View>
+
+      <Pressable
+        ref={menuRef}
+        onPress={openMenu}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`${place.name} 더보기`}
+        style={styles.menuButton}
+      >
+        <MoreVertical size={20} color={Palette.gray[300]} strokeWidth={1.75} />
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: Spacing.two,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    borderRadius: Radius.medium,
+    borderWidth: 1,
+    borderColor: Palette.border.disabled,
+    backgroundColor: Palette.background.base,
+  },
+  pressed: {
+    backgroundColor: Palette.background.subtle,
+  },
+  body: {
+    flex: 1,
+    gap: 6,
+  },
+  statusLine: {
+    marginTop: Spacing.half,
+  },
+  menuButton: {
+    marginTop: -Spacing.one,
+    marginRight: -Spacing.two,
+    padding: Spacing.one,
+  },
+});

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,69 @@
+import { Map, type LucideIcon } from "lucide-react-native";
+import { StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+
+export type EmptyStateProps = {
+  message: string;
+  Icon?: LucideIcon;
+  /** null이면 액션 버튼 숨김. */
+  actionLabel?: string | null;
+  onAction?: () => void;
+};
+
+export function EmptyState({
+  message,
+  Icon = Map,
+  actionLabel = "지도로 가기",
+  onAction,
+}: EmptyStateProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconWrap}>
+        <Icon size={30} color={Palette.main[500]} />
+      </View>
+      <ThemedText
+        type="label03"
+        color={Palette.gray[500]}
+        style={styles.message}
+      >
+        {message}
+      </ThemedText>
+      {actionLabel && onAction ? (
+        <Button
+          label={actionLabel}
+          variant="main"
+          onPress={onAction}
+          style={styles.button}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: Spacing.three,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: Spacing.four,
+  },
+  iconWrap: {
+    width: 64,
+    height: 64,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: "rgba(255, 154, 134, 0.12)",
+  },
+  message: {
+    textAlign: "center",
+  },
+  button: {
+    marginTop: Spacing.one,
+    paddingHorizontal: Spacing.five,
+  },
+});

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -1,0 +1,81 @@
+import { type LucideIcon } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { ThemedText } from "@/components/themed-text";
+import { Palette, Radius, Spacing } from "@/constants/theme";
+
+export type SegmentOption<T extends string> = {
+  value: T;
+  label: string;
+  Icon?: LucideIcon;
+};
+
+export type SegmentedControlProps<T extends string> = {
+  options: SegmentOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+};
+
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: SegmentedControlProps<T>) {
+  return (
+    <View style={styles.track}>
+      {options.map((option) => {
+        const selected = option.value === value;
+        const { Icon } = option;
+        const contentColor = selected ? Palette.gray[700] : Palette.gray[400];
+        return (
+          <Pressable
+            key={option.value}
+            onPress={() => onChange(option.value)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected }}
+            style={[styles.segment, selected && styles.segmentSelected]}
+          >
+            {Icon ? (
+              <Icon
+                size={18}
+                color={selected ? Palette.main[500] : Palette.gray[400]}
+                strokeWidth={selected ? 2.4 : 2}
+              />
+            ) : null}
+            <ThemedText type="subtitle04" color={contentColor}>
+              {option.label}
+            </ThemedText>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    flexDirection: "row",
+    gap: Spacing.one,
+    padding: Spacing.one,
+    borderRadius: Radius.large,
+    backgroundColor: Palette.gray[100],
+  },
+  segment: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.two,
+    paddingVertical: 12,
+    // 트랙 radius(large 20) − 트랙 패딩(one 4) = 16 이어야 안쪽 카드가 동심으로 맞는다.
+    borderRadius: Radius.large - Spacing.one,
+  },
+  segmentSelected: {
+    backgroundColor: Palette.white,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+});

--- a/src/mocks/courses.ts
+++ b/src/mocks/courses.ts
@@ -76,3 +76,10 @@ export const MOCK_COURSE_FALLBACK: Course = {
   walkPath: null,
   relaxed: true,
 };
+
+// 저장 코스(S-15)를 id로 재현(실제로는 GET /courses/{id}). 미매칭 시 기본 코스 폴백.
+export function getCourseById(id: string): Course {
+  return (
+    [MOCK_COURSE, MOCK_COURSE_FALLBACK].find((c) => c.id === id) ?? MOCK_COURSE
+  );
+}

--- a/src/mocks/reviews.ts
+++ b/src/mocks/reviews.ts
@@ -323,6 +323,29 @@ export const MOCK_REVIEWS: Review[] = [
   },
 ];
 
+// [목] 로그인 사용자가 쓴 리뷰 id — 마이 리뷰수·S-17·여권 도장이 공유하는 단일 출처.
+const MY_REVIEW_IDS = [
+  "r-001",
+  "r-005",
+  "r-013",
+  "r-019",
+  "r-021",
+  "r-010",
+  "r-016",
+  "r-007",
+  "r-011",
+  "r-023",
+  "r-015",
+  "r-022",
+] as const;
+
+export function getMyReviews(): Review[] {
+  const mine = new Set<string>(MY_REVIEW_IDS);
+  return MOCK_REVIEWS.filter((r) => mine.has(r.id)).sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+}
+
 /** 특정 가게의 리뷰를 최신순으로 반환한다. */
 export function getPlaceReviews(placeId: string): Review[] {
   return MOCK_REVIEWS.filter((r) => r.placeId === placeId).sort((a, b) =>

--- a/src/mocks/saved.ts
+++ b/src/mocks/saved.ts
@@ -1,0 +1,36 @@
+import { MOCK_COURSE, MOCK_COURSE_FALLBACK } from "@/mocks/courses";
+import { MOCK_PLACES } from "@/mocks/places";
+import type { Course, SavedCoursePreview } from "@/types/course";
+import type { Place } from "@/types/place";
+
+// 저장(플로우 C) 화면 개발용 목. 실연동 시 이 파일만 지우면 되도록 Place/Course 외 타입을 만들지 말 것.
+
+export const MOCK_SAVED_PLACES: Place[] = ["p-002", "p-001", "p-004", "p-016"]
+  .map((id) => MOCK_PLACES.find((place) => place.id === id))
+  .filter((place): place is Place => place !== undefined);
+
+function toPreview(
+  course: Course,
+  title: string,
+  createdAt: string,
+): SavedCoursePreview {
+  return {
+    id: course.id,
+    title,
+    size: course.size,
+    storeCount: course.waypoints.length,
+    storeNames: course.waypoints.map((waypoint) => waypoint.name),
+    totalDistance: course.totalDistance,
+    totalTime: course.totalTime,
+    createdAt,
+  };
+}
+
+export const MOCK_SAVED_COURSES: SavedCoursePreview[] = [
+  toPreview(MOCK_COURSE, "대형견 · 산책 · 반나절 코스", "2026-08-28T05:00:00Z"),
+  toPreview(
+    MOCK_COURSE_FALLBACK,
+    "서울숲 반나절 산책 코스",
+    "2026-08-10T02:30:00Z",
+  ),
+];

--- a/src/mocks/user.ts
+++ b/src/mocks/user.ts
@@ -1,0 +1,32 @@
+import { MOCK_PLACES } from "@/mocks/places";
+import { getMyReviews } from "@/mocks/reviews";
+import type { PassportStamp, UserSummary } from "@/types/user";
+
+// 마이(플로우 D) 화면 개발용 목. 리뷰수·도장수는 getMyReviews에서 파생(화면 간 일관).
+// 실연동 시 이 파일만 지우면 되도록 User 외의 타입을 만들지 말 것.
+
+const storeName = (placeId: string) =>
+  MOCK_PLACES.find((place) => place.id === placeId)?.name ?? "";
+
+// 도장은 "들어갔어요" 리뷰에서만 생성(거절은 사진 없어 미지급).
+export const MOCK_PASSPORT: PassportStamp[] = getMyReviews()
+  .filter((review) => review.dogAllowed)
+  .map((review) => ({
+    id: `st-${review.id}`,
+    storeId: review.placeId,
+    storeName: storeName(review.placeId),
+    stampUrl: null,
+    // r-010은 원본 사진 없이 실루엣만 크게 나오는 폴백 케이스로 둔다.
+    photoUrl: review.id === "r-010" ? null : review.photoUrl,
+    createdAt: review.createdAt,
+  }));
+
+export const MOCK_USER: UserSummary = {
+  nickname: "나영",
+  reviewCount: getMyReviews().length,
+  stampCount: MOCK_PASSPORT.length,
+};
+
+export function getStamp(id: string): PassportStamp | undefined {
+  return MOCK_PASSPORT.find((stamp) => stamp.id === id);
+}

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -54,6 +54,19 @@ export interface CourseWaypoint {
   } | null;
 }
 
+// 저장 목록(S-15 코스 탭)용 요약(`GET /user/me/saved-courses`).
+// 탭 시 이 id를 재사용해 S-11을 재현한다(재계산 없음).
+export interface SavedCoursePreview {
+  id: string;
+  title: string;
+  size: SizeKey;
+  storeCount: number;
+  storeNames: string[];
+  totalDistance: number;
+  totalTime: number;
+  createdAt: string;
+}
+
 /**
  * 추천된 코스. 저장(`POST /courses`) 시에도 이 id를 재사용한다.
  */

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,20 @@
+// 마이(플로우 D) API 스펙 초안 — `GET /user/me`, `/user/me/passport`(+`/{id}`).
+// 임의로 바꾸지 말 것: 백엔드 담당과 먼저 합의한다.
+
+export interface UserSummary {
+  nickname: string;
+  reviewCount: number;
+  /** 모은 도장 수(= 여권 도장 개수에서 파생). */
+  stampCount: number;
+}
+
+// 목록(`/user/me/passport`)·상세(`/{id}`) 응답에서 UI가 쓰는 필드를 합친 형태.
+export interface PassportStamp {
+  id: string;
+  storeId: string;
+  storeName: string;
+  stampUrl: string | null;
+  /** 원본 사진. 세그멘테이션 미달 시 null → 실루엣 폴백. */
+  photoUrl: string | null;
+  createdAt: string;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -9,3 +9,14 @@ export function formatReviewDate(iso: string): string {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}.${month}.${day}`;
 }
+
+/** ISO 8601 문자열을 "MM.DD"로 짧게 표시한다(내 리뷰 목록·도장 등 좁은 영역). */
+export function formatMonthDay(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${month}.${day}`;
+}


### PR DESCRIPTION
## 🎯 작업 내용

Figma 와이어프레임에 기반하여 저장(플로우 C)·마이(플로우 D) 화면 UI를 구현했습니다.
데이터는 목(`src/mocks/`)을 쓰고 **API 연동은 범위 밖**이며, `GET /user/store`·`/user/me/saved-courses`·`/user/me`·`/user/me/passport`(+`/{id}`) 초안에 맞춰 props/타입만 정합을 맞췄습니다.

```
[저장 탭] → [S-15 저장] 장소/코스 세그먼트 ─ 장소 → 상세(S-05) / 코스 → 결과 재현(S-11)
[마이 탭] → [S-16 마이] ─ 리뷰 수 → [S-17 내 리뷰] · 여권(S-13) ─ 도장 → [S-14 도장 상세 모달]
```

> 이슈 대비 조정: 저장 해제는 스와이프 → ⋮ 메뉴로, S-17은 요청에 따라 썸네일을 표시(들어갔어요 리뷰만), 이미지 저장은 안내(no-op)로 처리했습니다.

## 📝 변경 사항

**타입 · 목데이터 · 유틸**

- `src/types/user.ts` — 마이 요약·여권 도장 타입(`GET /user/me`·`/user/me/passport` 초안)
- `src/types/course.ts` — 저장 코스 미리보기 타입 `SavedCoursePreview` 추가
- `src/mocks/user.ts` — 마이 요약·여권 도장 목(리뷰/도장 수 파생)
- `src/mocks/saved.ts` — 저장 장소·코스 목
- `src/mocks/courses.ts` — `getCourseById()`(저장 코스 재현)
- `src/mocks/reviews.ts` — `getMyReviews()`(마이·S-17·여권 공유 단일 출처)
- `src/utils/date.ts` — `formatMonthDay()` 추가

**공용 UI 컴포넌트**

- `src/components/ui/segmented-control.tsx` — 세그먼트 컨트롤(회색 트랙 + 흰 선택 카드)
- `src/components/ui/empty-state.tsx` — 목록 빈 상태(안내 + 지도 버튼)

**저장 (S-15)**

- `src/components/saved/saved-place-row.tsx` · `saved-course-row.tsx` — 장소/코스 카드(⋮ 메뉴, 코스 이름 인라인 수정)
- `src/app/(main)/saved.tsx` — 장소/코스 세그먼트·삭제 팝업·빈 상태
- `src/app/recommend/result.tsx` — 저장 코스 id 재현·닫기만 노출, 코스 결과 화면 정리

**마이 · 여권 (S-16 · S-13)**

- `src/components/my/passport-book.tsx` · `passport.tsx` · `passport-slots.ts` · `passport-stamp.tsx` — 펼친 책 크롭 여권·도장 배치·페이지네이션
- `src/components/my/profile-summary-card.tsx` — 상단 요약 카드(리뷰 수 → S-17)
- `src/app/(main)/my.tsx` — 마이 화면(요약 + 여권 임베드 + 로그아웃/회원 탈퇴)

**내 리뷰 · 도장 모달 (S-17 · S-14)**

- `src/components/review/my-review-item.tsx` — 내 리뷰 행(결과 배지·작성일·썸네일)
- `src/app/my/reviews.tsx` — 내 리뷰 목록(최신순)
- `src/app/my/stamp/[stampId].tsx` — 도장 상세 모달
- `src/app/_layout.tsx` — 신규 라우트 2종(`my/reviews`·`my/stamp/[stampId]`) 등록

## 🔗 관련 이슈

- Closes #17

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음 — 새 네이티브 의존성·설정 변경 없음(`react-native-svg` 등 기존 의존성만 사용).

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android

## 📸 스크린샷 / 화면 녹화

| 저장 · 장소 | 저장 · 코스 | 코스 이름 수정 | 코스 상세 재현 |
| --- | --- | --- | --- |
| <img width="1080" height="2400" alt="01_저장_장소" src="https://github.com/user-attachments/assets/ed42c258-ebee-40fe-92f3-315760a0f0f4" /> | <img width="1080" height="2400" alt="02_저장_코스" src="https://github.com/user-attachments/assets/a6907770-d35d-4e30-91c9-8271305e53c2" /> | <img width="1080" height="2400" alt="03_코스_이름수정" src="https://github.com/user-attachments/assets/e9f5294d-f1d6-4a7d-8eda-a1cc69486a65" /> | <img width="1080" height="2400" alt="04_코스상세_S11" src="https://github.com/user-attachments/assets/d9e0793c-1798-49c4-a8e8-d758dbef5c0c" /> |

| 마이 (S-16 · S-13) | 내 리뷰 (S-17) | 도장 상세 모달 (S-14) |
| --- | --- | --- |
| <img width="1080" height="2400" alt="05_마이_S16_S13" src="https://github.com/user-attachments/assets/a9aa1ff5-b862-43e6-a8ad-aedc1be1a731" /> | <img width="1080" height="2400" alt="06_내리뷰_S17" src="https://github.com/user-attachments/assets/1a52787f-a56f-4a59-9b3e-f7d700edafe7" /> | <img width="1080" height="2400" alt="07_도장모달_S14" src="https://github.com/user-attachments/assets/c05361ba-ddb5-43d2-a1ff-9b926056deb0" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 마이 페이지에서 사용자 정보, 리뷰, 여권 도장을 확인할 수 있습니다.
  - 리뷰 목록과 도장 상세 정보를 조회하고 관련 장소로 이동할 수 있습니다.
  - 저장한 장소와 코스를 탭별로 확인하고, 이름 변경·삭제를 지원합니다.
  - 추천 결과에서 저장된 코스를 다시 확인할 수 있습니다.
  - 리뷰·저장 항목이 없을 때 안내와 지도 이동 기능을 제공합니다.
  - 로그아웃 및 회원 탈퇴 확인 절차를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->