### PR TITLE
[FEAT] 공통 API 통신 레이어 구축 및 React Query 세팅

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -1,0 +1,74 @@
+# API 아키텍처 가이드
+
+백엔드 연동 공통 규약. 화면을 붙일 때 이 패턴을 따른다. 데이터는 목(`src/mocks`)에서 시작해
+**목 호출 → 훅 교체 → 목 삭제** 순으로 연동한다.
+
+## 폴더 구조
+
+```
+src/api/
+  client.ts        axios 인스턴스 + 토큰 인터셉터(요청) + 에러 정규화(응답)
+  endpoints.ts     도메인별 엔드포인트 상수 · path 함수
+  query-client.ts  React Query 전역 QueryClient (app/_layout에서 주입)
+  query-keys.ts    도메인별 쿼리 키 팩토리
+  http-error.ts    공통 ApiHttpError + axios 에러 정규화
+  user.ts          도메인별 단일 호출 함수(예시) — store/review/course는 이 파일을 본떠 추가
+src/types/         Request/Response 타입(백엔드 합의 스펙) — api 함수가 재사용
+src/hooks/         화면 단 react-query 훅(useXxxQuery / useXxxMutation)
+src/mocks/         연동되면 도메인별로 삭제
+```
+
+레이어: **컴포넌트 → 훅(`src/hooks`) → 도메인 함수(`src/api/<domain>.ts`) → `apiClient`**.
+컴포넌트는 `apiClient`를 직접 부르지 않는다.
+
+## 요청/응답 흐름
+
+1. 도메인 함수가 `apiClient` + `API_ENDPOINTS`로 호출한다.
+2. 서버 원본(snake_case/enum)을 **함수 경계에서 앱 타입(camelCase)으로 매핑**해 반환한다.
+3. 훅이 `queryKeys`로 캐시하고, 컴포넌트는 훅만 쓴다.
+
+## 인증
+
+- **access token**: 요청 인터셉터가 SecureStore에서 읽어 `Authorization: Bearer`로 자동 주입.
+- **로그인**: access는 응답 **헤더**(`Authorization`), refresh는 **바디**로 온다 → `setAccessToken` / `setRefreshToken`.
+- **로그아웃/탈퇴**: `clearTokens()`로 둘 다 삭제. 로그아웃은 바디에 `refreshToken` 동봉.
+- **401 재발급**: refresh로 access 재발급 후 재시도하는 로직은 `client.ts` 응답 인터셉터에 TODO로 남겨둠 — **재발급 엔드포인트가 명세에 없어** 백엔드 확정 후 추가(아래 목록).
+
+## 에러 처리
+
+- 모든 응답 에러는 응답 인터셉터에서 `ApiHttpError`(`status` · `message` · `data`)로 정규화된다.
+- 화면/훅은 이 타입만 보고 상태코드로 분기(400/401/403/…). 서버 메시지는 `message`에 담김.
+
+## 쿼리 키 · 캐시
+
+- 키는 `queryKeys.<domain>....`만 사용(문자열 배열 직접 작성 금지).
+- 무효화는 계층으로: `invalidateQueries({ queryKey: queryKeys.user.all })`.
+- 기본 `staleTime` 60s · `retry` 1 (`query-client.ts`). 도메인별로 필요하면 훅에서 개별 조정.
+
+## 매핑 규칙 (프론트 기준 — 서버 불일치는 경계에서 흡수)
+
+- snake_case → camelCase (`store_name→name`, `review_count→reviewCount`, `totalDuration→totalTime`, `courseId→id`)
+- enum: `LARGE/SMALL_MEDIUM → large/smallMedium`, `PARK/CAFE/… → park/cafe/…`
+- 좌표: `geog { lat, lng } → { latitude, longitude }`
+- 상태: 서버 5단계(`*_LIKELY` 포함) → 앱 3단계(가능/불가/미확인)로 접기
+- 파일 업로드: RN `FormData`에 `{ uri, name, type }` append (웹 `File` 아님)
+
+## 연동 순서 (도메인마다)
+
+1. `endpoints.ts`에 경로 추가(필요 시).
+2. `src/types`에 Request/Response 타입 확인·보강.
+3. `src/api/<domain>.ts`에 단일 호출 함수 + 매핑 작성.
+4. `queryKeys`에 키 추가 → `src/hooks`에 훅 작성.
+5. 화면의 목 호출을 훅으로 교체 → 해당 `src/mocks` 파일 삭제.
+
+## 🔧 백엔드 확인 필요
+
+프론트 설계 기준으로 구현하고, 매핑으로 못 메우는 항목만 아래로 추적한다.
+
+- `GET /user/me/reviews` 신설 — 본인 리뷰 목록(S-17), `store_name`·`type` 포함
+- `GET /user/store` 응답에 `address` 추가 — 저장 장소 카드 도로명주소
+- `GET /user/me`에 `stamp_count` 추가 — "모은 도장 수"(현재 파생 불가)
+- 여권 preview(`GET /user/me/passport`) 응답 형태 확정(배열/래핑)
+- 상태 등급 5↔3단계 표기 정책 합의
+- 401 access **재발급 엔드포인트** 명세 필요(refresh 흐름 완성용)
+- `DELETE /course/{courseId}` 경로 단수/복수 확인

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import * as SecureStore from "expo-secure-store";
 
+import { toApiHttpError } from "@/api/http-error";
+
 /**
  * [환경변수 함정] RN에는 process.env가 없다.
  * Expo가 번들 타임에 EXPO_PUBLIC_ 접두사가 붙은 값만 문자열로 치환해준다.
@@ -12,6 +14,7 @@ import * as SecureStore from "expo-secure-store";
 export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? "";
 
 export const ACCESS_TOKEN_KEY = "walwang.accessToken";
+export const REFRESH_TOKEN_KEY = "walwang.refreshToken";
 
 // axios는 default export에 create를 노출하는데, import/no-named-as-default-member가
 // 이를 오탐으로 잡는다. axios.create는 정식 사용법이라 이 줄만 규칙을 끈다.
@@ -42,10 +45,37 @@ apiClient.interceptors.request.use(async (config) => {
   return config;
 });
 
+/**
+ * 응답 에러를 공통 ApiHttpError로 정규화한다. 화면/훅은 이 타입만 보고 분기한다.
+ * [TODO] 401 시 refreshToken으로 access 재발급 후 재시도 — 재발급 엔드포인트 미정이라
+ * 백엔드 확정 후 이 인터셉터에 추가한다(백엔드 확인 목록 참고).
+ */
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => Promise.reject(toApiHttpError(error)),
+);
+
 export async function setAccessToken(token: string) {
   await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, token);
 }
 
 export async function clearAccessToken() {
   await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+}
+
+export async function getRefreshToken() {
+  return SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function setRefreshToken(token: string) {
+  await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, token);
+}
+
+export async function clearRefreshToken() {
+  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}
+
+/** 로그인/로그아웃/탈퇴에서 두 토큰을 함께 정리할 때 사용. */
+export async function clearTokens() {
+  await Promise.all([clearAccessToken(), clearRefreshToken()]);
 }

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,0 +1,36 @@
+// 도메인별 API 엔드포인트. path 파라미터가 있으면 함수로 둔다.
+// 명세(08.28판) 기준. baseURL은 apiClient에서 붙으므로 여기선 경로만.
+export const API_ENDPOINTS = {
+  user: {
+    signUp: "/user/signUp",
+    login: "/user/login",
+    logout: "/user/logout",
+    me: "/user/me", // GET(내 정보) · PATCH(수정) · DELETE(탈퇴)
+    checkEmail: "/user/check-email",
+    checkNickname: "/user/check-nickname",
+    savedStores: "/user/store",
+    savedCourses: "/user/me/saved-courses",
+    passport: "/user/me/passport",
+    passportDetail: (passportId: string) => `/user/me/passport/${passportId}`,
+  },
+  store: {
+    list: "/stores",
+    search: "/stores/search",
+    detail: (storeId: string) => `/stores/${storeId}`,
+    reviews: (storeId: string) => `/stores/${storeId}/reviews`,
+    save: (storeId: string) => `/stores/${storeId}/save`, // POST 저장 · DELETE 해제
+  },
+  review: {
+    base: "/reviews", // POST 등록
+    receiptVerify: "/reviews/receipt-verify",
+    detail: (reviewId: string) => `/reviews/${reviewId}`, // DELETE
+    tags: "/tags",
+  },
+  course: {
+    recommend: "/courses/recommend",
+    base: "/courses", // POST 저장
+    detail: (courseId: string) => `/courses/${courseId}`,
+    // 명세엔 삭제가 /course/{id}(단수)로 적혀 있음 — 오타로 보고 /courses 사용, 백엔드 확인 필요.
+    remove: (courseId: string) => `/courses/${courseId}`,
+  },
+} as const;

--- a/src/api/http-error.ts
+++ b/src/api/http-error.ts
@@ -1,0 +1,33 @@
+import axios from "axios";
+
+/**
+ * 앱 전역 공통 API 에러. 화면/훅은 이 타입만 보고 상태코드·메시지로 분기한다.
+ * 서버는 body에 정확한 에러 메시지를 담아준다(명세 공통 규약).
+ */
+export class ApiHttpError extends Error {
+  readonly status: number;
+  readonly data: unknown;
+
+  constructor(status: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "ApiHttpError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+/** axios 에러 → ApiHttpError로 정규화. 응답 인터셉터에서 사용한다. */
+export function toApiHttpError(error: unknown): ApiHttpError {
+  // eslint-disable-next-line import/no-named-as-default-member
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status ?? 0;
+    const body = error.response?.data as { message?: string } | undefined;
+    const message =
+      body?.message ?? error.message ?? "요청을 처리하지 못했어요.";
+    return new ApiHttpError(status, message, error.response?.data);
+  }
+  if (error instanceof Error) {
+    return new ApiHttpError(0, error.message);
+  }
+  return new ApiHttpError(0, "알 수 없는 오류가 발생했어요.");
+}

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/react-query";
+
+// 전역 React Query 설정. Provider는 app/_layout.tsx에서 이 인스턴스를 주입한다.
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      retry: 1,
+    },
+  },
+});

--- a/src/api/query-keys.ts
+++ b/src/api/query-keys.ts
@@ -1,0 +1,34 @@
+// 도메인별 React Query 키 팩토리. 무효화(invalidate) 범위를 계층으로 잡을 수 있게 한다.
+// 예: queryClient.invalidateQueries({ queryKey: queryKeys.user.all })
+
+type StoreListParams = {
+  lat: number;
+  lng: number;
+  radius?: number;
+  size?: string;
+};
+
+export const queryKeys = {
+  user: {
+    all: ["user"] as const,
+    me: () => ["user", "me"] as const,
+    savedStores: () => ["user", "savedStores"] as const,
+    savedCourses: () => ["user", "savedCourses"] as const,
+    passport: (page: number) => ["user", "passport", page] as const,
+    passportDetail: (id: string) => ["user", "passport", "detail", id] as const,
+    myReviews: (page?: number) => ["user", "reviews", page] as const,
+  },
+  store: {
+    all: ["store"] as const,
+    list: (params: StoreListParams) => ["store", "list", params] as const,
+    search: (keyword: string) => ["store", "search", keyword] as const,
+    detail: (id: string) => ["store", "detail", id] as const,
+    reviews: (id: string, page?: number) =>
+      ["store", "reviews", id, page] as const,
+  },
+  course: {
+    all: ["course"] as const,
+    detail: (id: string) => ["course", "detail", id] as const,
+  },
+  tags: () => ["tags"] as const,
+} as const;

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,60 @@
+import {
+  apiClient,
+  clearTokens,
+  getRefreshToken,
+  setAccessToken,
+  setRefreshToken,
+} from "@/api/client";
+import { API_ENDPOINTS } from "@/api/endpoints";
+import type {
+  UserInfoResponse,
+  UserLoginRequest,
+  UserSummary,
+} from "@/types/user";
+
+// user 도메인 단일 호출 함수. 다른 도메인(store/review/course)도 이 파일을 본떠 추가한다.
+
+// 로그인: access는 응답 헤더(Authorization), refresh는 바디로 온다.
+export async function login(body: UserLoginRequest): Promise<void> {
+  const res = await apiClient.post<{ refreshToken: string }>(
+    API_ENDPOINTS.user.login,
+    body,
+  );
+  const auth = res.headers.authorization ?? res.headers.Authorization;
+  const access =
+    typeof auth === "string" ? auth.replace(/^Bearer\s+/i, "") : null;
+  if (access) {
+    await setAccessToken(access);
+  }
+  if (res.data?.refreshToken) {
+    await setRefreshToken(res.data.refreshToken);
+  }
+}
+
+// 내 정보: 서버 snake_case → UserSummary(camel) 매핑.
+// stampCount는 명세에 없어 0으로 둔다(백엔드 stamp_count 추가 시 반영 — 백엔드 확인 목록).
+export async function getMyProfile(): Promise<UserSummary> {
+  const { data } = await apiClient.get<UserInfoResponse>(API_ENDPOINTS.user.me);
+  return {
+    nickname: data.nickname,
+    reviewCount: data.review_count,
+    stampCount: 0,
+  };
+}
+
+export async function logout(): Promise<void> {
+  const refreshToken = await getRefreshToken();
+  try {
+    await apiClient.post(API_ENDPOINTS.user.logout, { refreshToken });
+  } finally {
+    await clearTokens();
+  }
+}
+
+export async function deleteUser(): Promise<void> {
+  try {
+    await apiClient.delete(API_ENDPOINTS.user.me);
+  } finally {
+    await clearTokens();
+  }
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -6,6 +6,7 @@ import {
   setRefreshToken,
 } from "@/api/client";
 import { API_ENDPOINTS } from "@/api/endpoints";
+import { ApiHttpError } from "@/api/http-error";
 import type {
   UserInfoResponse,
   UserLoginRequest,
@@ -23,12 +24,15 @@ export async function login(body: UserLoginRequest): Promise<void> {
   const auth = res.headers.authorization ?? res.headers.Authorization;
   const access =
     typeof auth === "string" ? auth.replace(/^Bearer\s+/i, "") : null;
-  if (access) {
-    await setAccessToken(access);
+  const refreshToken = res.data?.refreshToken;
+
+  // access(헤더)·refresh(바디) 둘 다 있어야 로그인 성공 — 하나라도 없으면 실패 처리.
+  if (!access || !refreshToken) {
+    throw new ApiHttpError(0, "로그인 응답에 토큰이 없어요.");
   }
-  if (res.data?.refreshToken) {
-    await setRefreshToken(res.data.refreshToken);
-  }
+
+  await setAccessToken(access);
+  await setRefreshToken(refreshToken);
 }
 
 // 내 정보: 서버 snake_case → UserSummary(camel) 매핑.
@@ -52,9 +56,7 @@ export async function logout(): Promise<void> {
 }
 
 export async function deleteUser(): Promise<void> {
-  try {
-    await apiClient.delete(API_ENDPOINTS.user.me);
-  } finally {
-    await clearTokens();
-  }
+  // 탈퇴가 성공한 뒤에만 토큰을 지운다(실패 시 계정은 남아있으므로 로그인 유지).
+  await apiClient.delete(API_ENDPOINTS.user.me);
+  await clearTokens();
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,19 +1,12 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { DefaultTheme, Stack, ThemeProvider } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
-SplashScreen.preventAutoHideAsync();
+import { queryClient } from "@/api/query-client";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 60 * 1000,
-      retry: 1,
-    },
-  },
-});
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   return (

--- a/src/hooks/use-login-mutation.ts
+++ b/src/hooks/use-login-mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { login } from "@/api/user";
+
+// 로그인 성공 시 토큰이 저장되므로 user 관련 쿼리를 무효화해 재조회하게 한다.
+export function useLoginMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: login,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.all });
+    },
+  });
+}

--- a/src/hooks/use-my-profile-query.ts
+++ b/src/hooks/use-my-profile-query.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getMyProfile } from "@/api/user";
+
+// 화면 단 훅. 컴포넌트는 목 함수 대신 이 훅으로 마이 요약을 가져온다.
+export function useMyProfileQuery(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.user.me(),
+    queryFn: getMyProfile,
+    enabled: options.enabled ?? true,
+  });
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,6 +8,18 @@ export interface UserSummary {
   stampCount: number;
 }
 
+export interface UserLoginRequest {
+  email: string;
+  password: string;
+}
+
+// `GET /user/me` 서버 원본(snake_case). api 함수 경계에서 UserSummary로 매핑한다.
+export interface UserInfoResponse {
+  nickname: string;
+  email: string;
+  review_count: number;
+}
+
 // 목록(`/user/me/passport`)·상세(`/{id}`) 응답에서 UI가 쓰는 필드를 합친 형태.
 export interface PassportStamp {
   id: string;


### PR DESCRIPTION
## 🎯 작업 내용

백엔드 연동에 앞서 **프로젝트 전역 공통 API 통신 레이어와 React Query 세팅**을 구축했습니다.
각 화면을 제각각 붙이면 정리 비용이 커지므로 엔드포인트·쿼리키·에러·인증 흐름의 **단일 규약**을 먼저 정했습니다.

- 데이터는 목(`src/mocks`)에서 시작해 **목 호출 → 훅 교체 → 목 삭제** 순으로 연동합니다.
- 스펙 불일치는 **프론트 설계 기준**으로 구현하고 경계에서 매핑으로 흡수, 못 메우는 항목만 아래 `🔧 백엔드 확인 필요`로 추적합니다.
- 이번 PR은 **골격 + 예시 도메인(user)** 까지입니다. store/review/course 실연동은 후속.
- 폴더는 기존 구조(`src/api`·`types`·`hooks`)를 유지했습니다. (레퍼런스의 FSD는 개념만 이식)

**레이어**: 컴포넌트 → 훅(`src/hooks`) → 도메인 함수(`src/api/<domain>.ts`) → `apiClient`

## 📝 변경 사항

**공통 통신 모듈 (`src/api/`)**

- `query-client.ts` — 전역 `QueryClient`(`_layout`에서 분리, `staleTime` 60s·`retry` 1)
- `endpoints.ts` — 도메인별 엔드포인트 상수 + path 파라미터 함수화 (08.28 명세 기준)
- `query-keys.ts` — 도메인별 쿼리 키 팩토리(계층 무효화용)
- `http-error.ts` — 공통 `ApiHttpError` + axios 에러 정규화
- `client.ts` — 응답 인터셉터(에러 정규화) + refreshToken 저장/정리(`setRefreshToken`·`getRefreshToken`·`clearTokens`)
- `_layout.tsx` — 공유 `queryClient` 주입으로 변경

**도메인 API 함수 · 훅 (예시: user)**

- `src/api/user.ts` — `login`(access=응답 헤더·refresh=바디)·`getMyProfile`(snake→camel 매핑)·`logout`·`deleteUser`
- `src/types/user.ts` — `UserLoginRequest`·`UserInfoResponse` 추가
- `src/hooks/use-my-profile-query.ts` · `use-login-mutation.ts` — 화면 단 react-query 훅

**문서**

- `docs/api-architecture.md` — 구조·요청 흐름·인증·에러·쿼리키·매핑 규칙·연동 순서 + 백엔드 확인 필요 목록

## 🔗 관련 이슈

- Closes #19 

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음 — 새 네이티브 의존성·설정 변경 없음(axios·react-query·secure-store 기존 의존성만 사용).
- `.env`의 `EXPO_PUBLIC_API_BASE_URL`로 baseURL 주입(커밋 금지). 에뮬레이터에서 로컬 백엔드는 `10.0.2.2` 사용.

## 📱 동작 확인

- [x] 타입/컴파일 정합(`typecheck`·`lint`) 통과
- 런타임 E2E 검증은 **백엔드 + 로그인/회원가입 연동 이후** 가능(현재 서버·토큰 없음) → 후속에서 진행

## 📸 스크린샷 / 화면 녹화

- 해당 없음 (UI 변경 없음 — 통신 레이어 골격)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 로그인, 내 프로필 조회, 로그아웃 및 회원 탈퇴 기능을 백엔드와 연동했습니다.
  - 사용자·매장·리뷰·코스 API 연동 기반과 위치 기반 매장 조회를 추가했습니다.
  - 로그인 상태와 인증 토큰을 안전하게 관리합니다.
  - 데이터 조회 캐시와 자동 갱신 규칙을 적용했습니다.

- **개선**
  - API 오류를 일관된 형식으로 처리합니다.
  - 로그인 후 사용자 정보가 최신 상태로 반영됩니다.
  - 회원 탈퇴가 완료된 경우에만 인증 정보를 삭제합니다.

- **문서**
  - 백엔드 연동, 인증, 오류 처리 및 데이터 변환 표준 가이드를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->