### PR TITLE
[FEAT] 갱신된 백엔드 스펙 반영

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -106,6 +106,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       {
         android: {
           extraMavenRepos: ["https://repository.map.naver.com/archive/maven"],
+          // 백엔드가 아직 HTTP(비-HTTPS)라 안드로이드 기본 cleartext 차단을 풀어준다.
+          // 운영에서 HTTPS로 바뀌면 제거할 것. 변경 후 네이티브 재빌드 필요(expo run:android).
+          usesCleartextTraffic: true,
         },
       },
     ],

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -32,7 +32,7 @@ src/mocks/         연동되면 도메인별로 삭제
 - **access token**: 요청 인터셉터가 SecureStore에서 읽어 `Authorization: Bearer`로 자동 주입.
 - **로그인**: access는 응답 **헤더**(`Authorization`), refresh는 **바디**로 온다 → `setAccessToken` / `setRefreshToken`.
 - **로그아웃/탈퇴**: `clearTokens()`로 둘 다 삭제. 로그아웃은 바디에 `refreshToken` 동봉.
-- **401 재발급**: refresh로 access 재발급 후 재시도하는 로직은 `client.ts` 응답 인터셉터에 TODO로 남겨둠 — **재발급 엔드포인트가 명세에 없어** 백엔드 확정 후 추가(아래 목록).
+- **401 재발급**: `POST /user/reissue`(바디 `{ refreshToken }`)로 access 재발급 후 원 요청 1회 재시도(`client.ts` 응답 인터셉터, single-flight). 새 access=응답 헤더·새 refresh=바디(14일 슬라이딩). 재발급 실패 시 `clearTokens()` 후 에러 → 화면에서 로그인 유도.
 
 ## 에러 처리
 
@@ -65,10 +65,10 @@ src/mocks/         연동되면 도메인별로 삭제
 
 프론트 설계 기준으로 구현하고, 매핑으로 못 메우는 항목만 아래로 추적한다.
 
-- `GET /user/me/reviews` 신설 — 본인 리뷰 목록(S-17), `store_name`·`type` 포함
-- `GET /user/store` 응답에 `address` 추가 — 저장 장소 카드 도로명주소
+- `GET /user/store` 응답에 `address` 추가 — 저장 장소 카드 도로명주소(현재 응답에 없음)
 - `GET /user/me`에 `stamp_count` 추가 — "모은 도장 수"(현재 파생 불가)
 - 여권 preview(`GET /user/me/passport`) 응답 형태 확정(배열/래핑)
 - 상태 등급 5↔3단계 표기 정책 합의
-- 401 access **재발급 엔드포인트** 명세 필요(refresh 흐름 완성용)
-- `DELETE /course/{courseId}` 경로 단수/복수 확인
+- `GET /user/me/reviews` 응답에 `store_name`·`type`(업종) 포함 여부 확인(S-17 표시용)
+
+해결됨: 본인 리뷰 목록(`GET /user/me/reviews`)·토큰 재발급(`POST /user/reissue`)은 서버에 존재 확인 → 반영 완료.

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -61,14 +61,14 @@ src/mocks/         연동되면 도메인별로 삭제
 4. `queryKeys`에 키 추가 → `src/hooks`에 훅 작성.
 5. 화면의 목 호출을 훅으로 교체 → 해당 `src/mocks` 파일 삭제.
 
-## 🔧 백엔드 확인 필요
+## ✅ 백엔드 확인 완료 (#19)
 
-프론트 설계 기준으로 구현하고, 매핑으로 못 메우는 항목만 아래로 추적한다.
+#19에서 요청했던 항목은 swagger(`/v3/api-docs`) 기준 모두 반영됨. 프론트는 경계에서 camelCase·enum만 매핑한다.
 
-- `GET /user/store` 응답에 `address` 추가 — 저장 장소 카드 도로명주소(현재 응답에 없음)
-- `GET /user/me`에 `stamp_count` 추가 — "모은 도장 수"(현재 파생 불가)
-- 여권 preview(`GET /user/me/passport`) 응답 형태 확정(배열/래핑)
-- 상태 등급 5↔3단계 표기 정책 합의
-- `GET /user/me/reviews` 응답에 `store_name`·`type`(업종) 포함 여부 확인(S-17 표시용)
-
-해결됨: 본인 리뷰 목록(`GET /user/me/reviews`)·토큰 재발급(`POST /user/reissue`)은 서버에 존재 확인 → 반영 완료.
+- ✅ `GET /user/me/reviews` — `storeName`·`type` 포함, `page/size`
+- ✅ `GET /user/store` — `address` 포함
+- ✅ `GET /user/me` — `stampCount` 포함
+- ✅ 여권 preview(`GET /user/me/passport`) — 정상 배열(`id`·`stampUrl`·`status`·`createdAt`)
+- ✅ 토큰 재발급 `POST /user/reissue`
+- ✅ `DELETE /course/{courseId}` (단수 경로 실재)
+- ✅ 상태 등급 — 서버 3단계(`POSSIBLE`/`IMPOSSIBLE`/`UNKNOWN`) → 앱 `allowed`/`denied`/`unknown`과 1:1(이름만 매핑, 5→3 접기 불필요)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -62,14 +62,15 @@ async function reissueTokens() {
   const auth = res.headers.authorization ?? res.headers.Authorization;
   const access =
     typeof auth === "string" ? auth.replace(/^Bearer\s+/i, "") : null;
-  if (!access) {
-    throw new Error("재발급 응답에 access 토큰 없음");
-  }
-  await setAccessToken(access);
   const newRefresh = (res.data as { refreshToken?: string })?.refreshToken;
-  if (newRefresh) {
-    await setRefreshToken(newRefresh);
+
+  // 서버가 refresh를 회전하므로 access·refresh 둘 다 온 경우만 성공 처리(옛 토큰 유지 방지).
+  if (!access || !newRefresh) {
+    throw new Error("재발급 응답에 토큰이 없음");
   }
+
+  await setAccessToken(access);
+  await setRefreshToken(newRefresh);
 }
 
 // 동시 401이 여러 번 재발급을 부르지 않도록 진행 중 Promise를 공유(single-flight).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { type InternalAxiosRequestConfig } from "axios";
 import * as SecureStore from "expo-secure-store";
 
 import { toApiHttpError } from "@/api/http-error";
@@ -46,13 +46,64 @@ apiClient.interceptors.request.use(async (config) => {
 });
 
 /**
- * 응답 에러를 공통 ApiHttpError로 정규화한다. 화면/훅은 이 타입만 보고 분기한다.
- * [TODO] 401 시 refreshToken으로 access 재발급 후 재시도 — 재발급 엔드포인트 미정이라
- * 백엔드 확정 후 이 인터셉터에 추가한다(백엔드 확인 목록 참고).
+ * refreshToken으로 access를 재발급한다(POST /user/reissue).
+ * 인터셉터 재귀를 피하려고 raw axios를 쓴다. 새 access=응답 헤더, 새 refresh=바디(14일 슬라이딩).
+ */
+async function reissueTokens() {
+  const refreshToken = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+  if (!refreshToken) {
+    throw new Error("refreshToken 없음");
+  }
+  const res = await axios.post(
+    `${API_BASE_URL}/user/reissue`,
+    { refreshToken },
+    { headers: { "Content-Type": "application/json" } },
+  );
+  const auth = res.headers.authorization ?? res.headers.Authorization;
+  const access =
+    typeof auth === "string" ? auth.replace(/^Bearer\s+/i, "") : null;
+  if (!access) {
+    throw new Error("재발급 응답에 access 토큰 없음");
+  }
+  await setAccessToken(access);
+  const newRefresh = (res.data as { refreshToken?: string })?.refreshToken;
+  if (newRefresh) {
+    await setRefreshToken(newRefresh);
+  }
+}
+
+// 동시 401이 여러 번 재발급을 부르지 않도록 진행 중 Promise를 공유(single-flight).
+let refreshPromise: Promise<void> | null = null;
+
+/**
+ * 응답 인터셉터: 401이면 refreshToken으로 1회 재발급 후 원 요청을 재시도한다.
+ * 재발급 실패 시 토큰을 정리하고 에러를 던진다(화면에서 로그인으로 유도).
+ * 그 외 에러는 공통 ApiHttpError로 정규화한다.
  */
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => Promise.reject(toApiHttpError(error)),
+  async (error) => {
+    const config = error?.config as
+      (InternalAxiosRequestConfig & { _retry?: boolean }) | undefined;
+    const status = error?.response?.status;
+    const url = config?.url ?? "";
+    const skip = url.includes("/user/reissue") || url.includes("/user/login");
+
+    if (status === 401 && config && !config._retry && !skip) {
+      config._retry = true;
+      try {
+        refreshPromise = refreshPromise ?? reissueTokens();
+        await refreshPromise;
+        refreshPromise = null;
+        return apiClient(config);
+      } catch {
+        refreshPromise = null;
+        await clearTokens();
+      }
+    }
+
+    return Promise.reject(toApiHttpError(error));
+  },
 );
 
 export async function setAccessToken(token: string) {

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -5,7 +5,9 @@ export const API_ENDPOINTS = {
     signUp: "/user/signUp",
     login: "/user/login",
     logout: "/user/logout",
+    reissue: "/user/reissue", // refreshToken으로 access 재발급(14일 슬라이딩)
     me: "/user/me", // GET(내 정보) · PATCH(수정) · DELETE(탈퇴)
+    myReviews: "/user/me/reviews", // 본인 리뷰 목록(page,size)
     checkEmail: "/user/check-email",
     checkNickname: "/user/check-nickname",
     savedStores: "/user/store",

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -8,8 +8,8 @@ import {
 import { API_ENDPOINTS } from "@/api/endpoints";
 import { ApiHttpError } from "@/api/http-error";
 import type {
-  UserInfoResponse,
   UserLoginRequest,
+  UserProfileResponse,
   UserSummary,
 } from "@/types/user";
 
@@ -35,14 +35,15 @@ export async function login(body: UserLoginRequest): Promise<void> {
   await setRefreshToken(refreshToken);
 }
 
-// 내 정보: 서버 snake_case → UserSummary(camel) 매핑.
-// stampCount는 명세에 없어 0으로 둔다(백엔드 stamp_count 추가 시 반영 — 백엔드 확인 목록).
+// 내 정보. swagger 응답이 camelCase(UserProfileResponse)라 필요한 필드만 추린다.
 export async function getMyProfile(): Promise<UserSummary> {
-  const { data } = await apiClient.get<UserInfoResponse>(API_ENDPOINTS.user.me);
+  const { data } = await apiClient.get<UserProfileResponse>(
+    API_ENDPOINTS.user.me,
+  );
   return {
     nickname: data.nickname,
-    reviewCount: data.review_count,
-    stampCount: 0,
+    reviewCount: data.reviewCount,
+    stampCount: data.stampCount,
   };
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -13,11 +13,14 @@ export interface UserLoginRequest {
   password: string;
 }
 
-// `GET /user/me` 서버 원본(snake_case). api 함수 경계에서 UserSummary로 매핑한다.
-export interface UserInfoResponse {
-  nickname: string;
+// `GET /user/me` 서버 응답(swagger UserProfileResponse, camelCase).
+export interface UserProfileResponse {
+  userId: number;
   email: string;
-  review_count: number;
+  nickname: string;
+  reviewCount: number;
+  stampCount: number;
+  savedStoreCount: number;
 }
 
 // 목록(`/user/me/passport`)·상세(`/{id}`) 응답에서 UI가 쓰는 필드를 합친 형태.


### PR DESCRIPTION
## 🎯 작업 내용

-  #19 에서 백엔드에 요청한 사항이 갱신된 백엔드 스펙에 프론트를 맞췄습니다.
주요 변경은 **refreshToken 도입(14일 슬라이딩)** 과 **응답 형식 camelCase** 입니다.

## 📝 변경 사항

- `src/api/client.ts` — 401 재발급 흐름: `POST /user/reissue`로 access 재발급 후 원 요청 1회 재시도(동시 401 single-flight), 실패 시 `clearTokens()`
- `src/api/endpoints.ts` — `reissue`·`myReviews` 엔드포인트 추가
- `src/api/user.ts` · `src/types/user.ts` — `getMyProfile`을 swagger `UserProfileResponse`(camelCase, `stampCount` 포함)에 맞춰 타입·매핑 교체
- `app.config.ts` — HTTP 백엔드 연동용 `usesCleartextTraffic: true` (운영 HTTPS 전환 시 제거)
- `docs/api-architecture.md` — 재발급 흐름·백엔드 확인 목록 갱신

## 🔗 관련 이슈

- #19 
- #20 

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- [x] `app.config.ts`(cleartext) 변경 → `npx expo run:android` 재빌드 후 반영 확인 필요
- [x] `.env`에 `EXPO_PUBLIC_API_BASE_URL=http://54.180.141.88:8080` 설정(로컬, 커밋 제외) → 변경 후 `npx expo start -c`

## 📱 동작 확인

- [x] typecheck · lint 통과
- 런타임 연동 검증은 재빌드(`expo run:android`) + 로그인 연동 이후 진행

## 📸 스크린샷 / 화면 녹화

- 해당 없음 (통신 레이어 정합, UI 변경 없음)

## 📚 참고 사항

swagger 확인 결과, #19에서 백엔드에 요청한 항목이 **모두 반영**됨:

- ✅ `GET /user/me/reviews` (`storeName`·`type` 포함)
- ✅ `GET /user/store`에 `address` 추가
- ✅ `GET /user/me`에 `stampCount` 추가
- ✅ 여권 preview 응답 정상 배열 (+`status`)
- ✅ `POST /user/reissue` 토큰 재발급
- ✅ `DELETE /course/{courseId}` (단수 경로 실재)
- ✅ 상태 등급도 3단계(`POSSIBLE/IMPOSSIBLE/UNKNOWN`)로 확정 → 프론트 3단계와 1:1(이름만 매핑)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능
- 인증 만료 시 토큰을 자동으로 재발급하고, 실패한 요청을 한 번 재시도합니다.
- 본인이 작성한 리뷰 목록을 조회할 수 있습니다.
- 사용자 프로필에 리뷰 수, 스탬프 수, 저장한 매장 수를 정확히 표시합니다.

## 버그 수정
- 토큰 재발급 응답이 불완전하거나 실패하면 기존 인증 정보를 유지하지 않고 다시 로그인을 안내합니다.
- 비HTTPS 백엔드와의 통신을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->