### PR TITLE
[FEAT] 로그인·회원가입 API 연동  

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,6 +42,11 @@ apiClient.interceptors.request.use(async (config) => {
     config.headers.Authorization = `Bearer ${token}`;
   }
 
+  // dev 전용 요청 로깅. adb logcat -s ReactNativeJS:V 로 확인. 프로덕션 번들엔 포함되지 않음.
+  if (__DEV__) {
+    console.info(`[API →] ${config.method?.toUpperCase()} ${config.url}`);
+  }
+
   return config;
 });
 
@@ -82,12 +87,25 @@ let refreshPromise: Promise<void> | null = null;
  * 그 외 에러는 공통 ApiHttpError로 정규화한다.
  */
 apiClient.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    // dev 전용 응답 로깅.
+    if (__DEV__) {
+      console.info(`[API ←] ${response.status} ${response.config.url}`);
+    }
+    return response;
+  },
   async (error) => {
     const config = error?.config as
       (InternalAxiosRequestConfig & { _retry?: boolean }) | undefined;
     const status = error?.response?.status;
     const url = config?.url ?? "";
+
+    // dev 전용 에러 로깅(status·경로·서버 메시지).
+    if (__DEV__) {
+      const body = error?.response?.data as { message?: string } | undefined;
+      console.info(`[API ✗] ${status ?? "-"} ${url}`, body?.message ?? "");
+    }
+
     const skip = url.includes("/user/reissue") || url.includes("/user/login");
 
     if (status === 401 && config && !config._retry && !skip) {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -85,8 +85,9 @@ export async function getMyProfile(): Promise<UserSummary> {
 }
 
 export async function logout(): Promise<void> {
-  const refreshToken = await getRefreshToken();
+  // refresh 읽기 실패까지 포함해 어떤 경로로 끝나도 토큰은 정리한다(남은 토큰으로 자동 로그인 방지).
   try {
+    const refreshToken = await getRefreshToken();
     await apiClient.post(API_ENDPOINTS.user.logout, { refreshToken });
   } finally {
     await clearTokens();

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -10,10 +10,47 @@ import { ApiHttpError } from "@/api/http-error";
 import type {
   UserLoginRequest,
   UserProfileResponse,
+  UserSignUpRequest,
   UserSummary,
 } from "@/types/user";
 
 // user 도메인 단일 호출 함수. 다른 도메인(store/review/course)도 이 파일을 본떠 추가한다.
+
+// 회원가입: 성공(200) 시 바디·토큰이 없다 → 화면에서 이어서 login을 호출해 자동 로그인한다.
+// 이메일/닉네임이 이미 있으면 409가 온다(경계는 그대로 던지고 화면에서 인라인 처리).
+export async function signUp(body: UserSignUpRequest): Promise<void> {
+  await apiClient.post(API_ENDPOINTS.user.signUp, body);
+}
+
+// 이메일 중복 확인: 사용 가능이면 true, 중복(409)이면 false. 그 외 에러는 그대로 던진다.
+export async function checkEmailAvailable(email: string): Promise<boolean> {
+  try {
+    await apiClient.get(API_ENDPOINTS.user.checkEmail, { params: { email } });
+    return true;
+  } catch (error) {
+    if (error instanceof ApiHttpError && error.status === 409) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+// 닉네임 중복 확인: 사용 가능이면 true, 중복(409)이면 false.
+export async function checkNicknameAvailable(
+  nickname: string,
+): Promise<boolean> {
+  try {
+    await apiClient.get(API_ENDPOINTS.user.checkNickname, {
+      params: { nickname },
+    });
+    return true;
+  } catch (error) {
+    if (error instanceof ApiHttpError && error.status === 409) {
+      return false;
+    }
+    throw error;
+  }
+}
 
 // 로그인: access는 응답 헤더(Authorization), refresh는 바디로 온다.
 export async function login(body: UserLoginRequest): Promise<void> {

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -1,18 +1,26 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Image } from "expo-image";
 import { Link, useRouter } from "expo-router";
 import { Controller, useForm } from "react-hook-form";
-import { ScrollView, StyleSheet, TextInput, View } from "react-native";
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  ToastAndroid,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { z } from "zod";
 
-import { setAccessToken } from "@/api/client";
+import { ApiHttpError } from "@/api/http-error";
 import { ThemedText } from "@/components/themed-text";
 import { Button } from "@/components/ui/button";
 import { TextField } from "@/components/ui/text-field";
 import { MaxContentWidth, Palette, Radius, Spacing } from "@/constants/theme";
+import { useLoginMutation } from "@/hooks/use-login-mutation";
 
 const loginSchema = z.object({
   email: z
@@ -30,22 +38,38 @@ const LOGO = require("@/assets/images/logo.png");
 export default function LoginScreen() {
   const router = useRouter();
   const passwordRef = useRef<TextInput>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const loginMutation = useLoginMutation();
 
   const {
     control,
     handleSubmit,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm<LoginForm>({
     resolver: zodResolver(loginSchema),
     defaultValues: { email: "", password: "" },
     mode: "onTouched",
   });
 
-  // TODO(auth): 실제 로그인 API 배선 전까지 쓰는 임시 dev 우회.
-  // 더미 토큰을 저장하고 지도로 이동한다(다음 실행부터 게이트가 자동으로 /map).
-  const onSubmit = handleSubmit(async () => {
-    await setAccessToken("dev-token");
-    router.replace("/map");
+  // 로그인 성공 시 토큰이 저장되고 지도로 이동. 자격증명 오류(401)는 인라인, 그 외는 Alert(입력값 유지).
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    try {
+      await loginMutation.mutateAsync(values);
+      ToastAndroid.show("로그인됐어요!", ToastAndroid.SHORT);
+      router.replace("/map");
+    } catch (error) {
+      if (error instanceof ApiHttpError && error.status === 401) {
+        setSubmitError("이메일 또는 비밀번호가 올바르지 않아요.");
+        return;
+      }
+      Alert.alert(
+        "로그인 실패",
+        error instanceof ApiHttpError
+          ? error.message
+          : "네트워크 상태를 확인한 뒤 다시 시도해주세요.",
+      );
+    }
   });
 
   return (
@@ -66,6 +90,7 @@ export default function LoginScreen() {
             render={({ field: { onChange, onBlur, value } }) => (
               <TextField
                 label="이메일"
+                focusColor={Palette.border.default}
                 placeholder="name@email.com"
                 value={value}
                 onChangeText={onChange}
@@ -89,6 +114,7 @@ export default function LoginScreen() {
               <TextField
                 ref={passwordRef}
                 label="비밀번호"
+                focusColor={Palette.border.default}
                 placeholder="비밀번호를 입력해주세요"
                 value={value}
                 onChangeText={onChange}
@@ -104,7 +130,17 @@ export default function LoginScreen() {
           />
         </View>
 
-        <Button label="로그인" onPress={onSubmit} loading={isSubmitting} />
+        {submitError ? (
+          <ThemedText type="label05" color={Palette.error[300]}>
+            {submitError}
+          </ThemedText>
+        ) : null}
+
+        <Button
+          label="로그인"
+          onPress={onSubmit}
+          loading={loginMutation.isPending}
+        />
 
         <View style={styles.signupRow}>
           <ThemedText type="label04" color={Palette.gray[500]}>

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -146,8 +146,17 @@ export default function SignupScreen() {
     }
   };
 
+  const allAgreed = Object.values(agreements).every(Boolean);
+
   // 가입 → 자동 로그인 → 지도. 가입 직전 사이에 선점되면 409 → 이메일 재확인 유도.
   const onSubmit = handleSubmit(async (values) => {
+    // 키보드 '완료'는 버튼 disabled를 거치지 않으므로, 약관·중복확인·진행중 상태를 여기서 재확인한다.
+    if (!allAgreed || !emailChecked || !nicknameChecked) {
+      return;
+    }
+    if (signupMutation.isPending) {
+      return;
+    }
     try {
       await signupMutation.mutateAsync({
         email: values.email,
@@ -170,7 +179,6 @@ export default function SignupScreen() {
     }
   });
 
-  const allAgreed = Object.values(agreements).every(Boolean);
   const canSubmit = isValid && allAgreed && emailChecked && nicknameChecked;
 
   return (

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -2,23 +2,29 @@ import { useRef, useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Image } from "expo-image";
-import { Link } from "expo-router";
-import { Controller, useForm } from "react-hook-form";
+import { Link, useRouter } from "expo-router";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import {
+  Alert,
   Pressable,
   ScrollView,
   StyleSheet,
   TextInput,
+  ToastAndroid,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { z } from "zod";
 
+import { ApiHttpError } from "@/api/http-error";
 import { ThemedText } from "@/components/themed-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { TextField } from "@/components/ui/text-field";
 import { MaxContentWidth, Palette, Radius, Spacing } from "@/constants/theme";
+import { useCheckEmailMutation } from "@/hooks/use-check-email-mutation";
+import { useCheckNicknameMutation } from "@/hooks/use-check-nickname-mutation";
+import { useSignupMutation } from "@/hooks/use-signup-mutation";
 
 const AGREEMENTS = [
   { code: "TERMS_OF_SERVICE", label: "(필수) 이용약관 동의", more: true },
@@ -52,7 +58,14 @@ type SignupForm = z.infer<typeof signupSchema>;
 
 const LOGO = require("@/assets/images/logo.png");
 
+function errorMessage(error: unknown): string {
+  return error instanceof ApiHttpError
+    ? error.message
+    : "네트워크 상태를 확인한 뒤 다시 시도해주세요.";
+}
+
 export default function SignupScreen() {
+  const router = useRouter();
   const nicknameRef = useRef<TextInput>(null);
   const passwordRef = useRef<TextInput>(null);
   const passwordConfirmRef = useRef<TextInput>(null);
@@ -63,10 +76,21 @@ export default function SignupScreen() {
     AGE_14: false,
   });
 
+  // 마지막으로 "사용 가능"을 확인한 값. 입력을 바꾸면 현재 값과 달라져 재확인이 필요해진다.
+  const [checkedEmail, setCheckedEmail] = useState<string | null>(null);
+  const [checkedNickname, setCheckedNickname] = useState<string | null>(null);
+
+  const checkEmailMutation = useCheckEmailMutation();
+  const checkNicknameMutation = useCheckNicknameMutation();
+  const signupMutation = useSignupMutation();
+
   const {
     control,
     handleSubmit,
-    formState: { errors, isSubmitting, isValid },
+    trigger,
+    setError,
+    clearErrors,
+    formState: { errors, isValid },
   } = useForm<SignupForm>({
     resolver: zodResolver(signupSchema),
     defaultValues: {
@@ -78,10 +102,76 @@ export default function SignupScreen() {
     mode: "onTouched",
   });
 
-  const onSubmit = handleSubmit(async () => {});
+  // useWatch는 watch()와 달리 메모이제이션에 안전(React Compiler 경고 없음).
+  const emailValue = useWatch({ control, name: "email" }).trim();
+  const nicknameValue = useWatch({ control, name: "nickname" }).trim();
+  const emailChecked = checkedEmail !== null && checkedEmail === emailValue;
+  const nicknameChecked =
+    checkedNickname !== null && checkedNickname === nicknameValue;
+
+  // [중복 확인] 이메일: 형식 검증 통과 후 조회. 409면 인라인 에러, 200이면 확인 상태로.
+  const handleCheckEmail = async () => {
+    if (!(await trigger("email"))) {
+      return;
+    }
+    try {
+      const available = await checkEmailMutation.mutateAsync(emailValue);
+      if (available) {
+        clearErrors("email");
+        setCheckedEmail(emailValue);
+      } else {
+        setError("email", { message: "이미 사용 중인 이메일이에요." });
+        setCheckedEmail(null);
+      }
+    } catch (error) {
+      Alert.alert("확인 실패", errorMessage(error));
+    }
+  };
+
+  const handleCheckNickname = async () => {
+    if (!(await trigger("nickname"))) {
+      return;
+    }
+    try {
+      const available = await checkNicknameMutation.mutateAsync(nicknameValue);
+      if (available) {
+        clearErrors("nickname");
+        setCheckedNickname(nicknameValue);
+      } else {
+        setError("nickname", { message: "이미 사용 중인 닉네임이에요." });
+        setCheckedNickname(null);
+      }
+    } catch (error) {
+      Alert.alert("확인 실패", errorMessage(error));
+    }
+  };
+
+  // 가입 → 자동 로그인 → 지도. 가입 직전 사이에 선점되면 409 → 이메일 재확인 유도.
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await signupMutation.mutateAsync({
+        email: values.email,
+        nickname: values.nickname,
+        password: values.password,
+        agreements: AGREEMENTS.map((item) => ({
+          termCode: item.code,
+          agreed: agreements[item.code],
+        })),
+      });
+      ToastAndroid.show("회원가입이 완료됐어요!", ToastAndroid.SHORT);
+      router.replace("/map");
+    } catch (error) {
+      if (error instanceof ApiHttpError && error.status === 409) {
+        setError("email", { message: "이미 사용 중인 이메일이에요." });
+        setCheckedEmail(null);
+        return;
+      }
+      Alert.alert("회원가입 실패", errorMessage(error));
+    }
+  });
 
   const allAgreed = Object.values(agreements).every(Boolean);
-  const canSubmit = isValid && allAgreed;
+  const canSubmit = isValid && allAgreed && emailChecked && nicknameChecked;
 
   return (
     <SafeAreaView style={styles.screen}>
@@ -99,29 +189,43 @@ export default function SignupScreen() {
             control={control}
             name="email"
             render={({ field: { onChange, onBlur, value } }) => (
-              <TextField
-                label="이메일"
-                placeholder="name@email.com"
-                value={value}
-                onChangeText={onChange}
-                onBlur={onBlur}
-                error={errors.email?.message}
-                autoCapitalize="none"
-                autoCorrect={false}
-                autoComplete="email"
-                keyboardType="email-address"
-                returnKeyType="next"
-                onSubmitEditing={() => nicknameRef.current?.focus()}
-                submitBehavior="submit"
-                rightAccessory={
-                  <Button
-                    label="중복 확인"
-                    variant="main"
-                    onPress={() => {}}
-                    style={styles.checkButton}
-                  />
-                }
-              />
+              <View>
+                <TextField
+                  label="이메일"
+                  focusColor={Palette.border.default}
+                  placeholder="name@email.com"
+                  value={value}
+                  onChangeText={onChange}
+                  onBlur={onBlur}
+                  error={errors.email?.message}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  autoComplete="email"
+                  keyboardType="email-address"
+                  returnKeyType="next"
+                  onSubmitEditing={() => nicknameRef.current?.focus()}
+                  submitBehavior="submit"
+                  rightAccessory={
+                    <Button
+                      label="중복 확인"
+                      variant="main"
+                      onPress={handleCheckEmail}
+                      loading={checkEmailMutation.isPending}
+                      disabled={emailChecked}
+                      style={styles.checkButton}
+                    />
+                  }
+                />
+                {emailChecked && !errors.email ? (
+                  <ThemedText
+                    type="label06"
+                    color={Palette.success[300]}
+                    style={styles.successText}
+                  >
+                    사용 가능한 이메일이에요.
+                  </ThemedText>
+                ) : null}
+              </View>
             )}
           />
 
@@ -129,28 +233,42 @@ export default function SignupScreen() {
             control={control}
             name="nickname"
             render={({ field: { onChange, onBlur, value } }) => (
-              <TextField
-                ref={nicknameRef}
-                label="닉네임"
-                placeholder="2~10자"
-                value={value}
-                onChangeText={onChange}
-                onBlur={onBlur}
-                error={errors.nickname?.message}
-                autoCapitalize="none"
-                autoCorrect={false}
-                returnKeyType="next"
-                onSubmitEditing={() => passwordRef.current?.focus()}
-                submitBehavior="submit"
-                rightAccessory={
-                  <Button
-                    label="중복 확인"
-                    variant="main"
-                    onPress={() => {}}
-                    style={styles.checkButton}
-                  />
-                }
-              />
+              <View>
+                <TextField
+                  ref={nicknameRef}
+                  label="닉네임"
+                  focusColor={Palette.border.default}
+                  placeholder="2~10자"
+                  value={value}
+                  onChangeText={onChange}
+                  onBlur={onBlur}
+                  error={errors.nickname?.message}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="next"
+                  onSubmitEditing={() => passwordRef.current?.focus()}
+                  submitBehavior="submit"
+                  rightAccessory={
+                    <Button
+                      label="중복 확인"
+                      variant="main"
+                      onPress={handleCheckNickname}
+                      loading={checkNicknameMutation.isPending}
+                      disabled={nicknameChecked}
+                      style={styles.checkButton}
+                    />
+                  }
+                />
+                {nicknameChecked && !errors.nickname ? (
+                  <ThemedText
+                    type="label06"
+                    color={Palette.success[300]}
+                    style={styles.successText}
+                  >
+                    사용 가능한 닉네임이에요.
+                  </ThemedText>
+                ) : null}
+              </View>
             )}
           />
 
@@ -161,6 +279,7 @@ export default function SignupScreen() {
               <TextField
                 ref={passwordRef}
                 label="비밀번호"
+                focusColor={Palette.border.default}
                 placeholder="8자 이상"
                 value={value}
                 onChangeText={onChange}
@@ -183,6 +302,7 @@ export default function SignupScreen() {
               <TextField
                 ref={passwordConfirmRef}
                 label="비밀번호 확인"
+                focusColor={Palette.border.default}
                 placeholder="비밀번호 확인"
                 value={value}
                 onChangeText={onChange}
@@ -223,7 +343,7 @@ export default function SignupScreen() {
         <Button
           label="가입하기"
           onPress={onSubmit}
-          loading={isSubmitting}
+          loading={signupMutation.isPending}
           disabled={!canSubmit}
         />
 
@@ -277,6 +397,9 @@ const styles = StyleSheet.create({
     minHeight: 0,
     paddingVertical: Spacing.two,
     paddingHorizontal: Spacing.two,
+  },
+  successText: {
+    marginTop: Spacing.one,
   },
   agreements: {
     gap: Spacing.three,

--- a/src/app/(main)/my.tsx
+++ b/src/app/(main)/my.tsx
@@ -1,17 +1,26 @@
 import { useRouter } from "expo-router";
-import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  ToastAndroid,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Passport } from "@/components/my/passport";
 import { ProfileSummaryCard } from "@/components/my/profile-summary-card";
 import { ThemedText } from "@/components/themed-text";
 import { Palette, Spacing } from "@/constants/theme";
+import { useLogoutMutation } from "@/hooks/use-logout-mutation";
 import { MOCK_PASSPORT, MOCK_USER } from "@/mocks/user";
 import type { PassportStamp } from "@/types/user";
 
 export default function MyScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const logoutMutation = useLogoutMutation();
 
   const openReviews = () => router.push("/my/reviews");
 
@@ -27,7 +36,16 @@ export default function MyScreen() {
       {
         text: "로그아웃",
         style: "destructive",
-        onPress: () => router.replace("/login"),
+        onPress: async () => {
+          // 서버 호출이 실패해도 토큰은 정리되므로(logout()의 finally) 로그인으로 보낸다.
+          try {
+            await logoutMutation.mutateAsync();
+          } catch {
+            // 네트워크 실패는 무시 — 로컬 세션은 이미 정리됨.
+          }
+          ToastAndroid.show("로그아웃됐어요!", ToastAndroid.SHORT);
+          router.replace("/login");
+        },
       },
     ]);
 

--- a/src/hooks/use-check-email-mutation.ts
+++ b/src/hooks/use-check-email-mutation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { checkEmailAvailable } from "@/api/user";
+
+// 이메일 중복 확인. [중복 확인] 버튼에서 호출한다. data=true(사용 가능)/false(중복).
+export function useCheckEmailMutation() {
+  return useMutation({ mutationFn: checkEmailAvailable });
+}

--- a/src/hooks/use-check-nickname-mutation.ts
+++ b/src/hooks/use-check-nickname-mutation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { checkNicknameAvailable } from "@/api/user";
+
+// 닉네임 중복 확인. [중복 확인] 버튼에서 호출한다. data=true(사용 가능)/false(중복).
+export function useCheckNicknameMutation() {
+  return useMutation({ mutationFn: checkNicknameAvailable });
+}

--- a/src/hooks/use-logout-mutation.ts
+++ b/src/hooks/use-logout-mutation.ts
@@ -4,12 +4,12 @@ import { queryKeys } from "@/api/query-keys";
 import { logout } from "@/api/user";
 
 // 로그아웃. logout()이 서버 호출 성공/실패와 무관하게 토큰을 정리한다(api/user.ts의 finally).
-// 성공 시 캐시된 user 쿼리를 제거해 로그아웃 상태에서 재조회(401)를 막는다.
+// 토큰이 항상 정리되므로 캐시도 성공/실패 무관하게(onSettled) 제거해 이전 사용자 데이터 재사용을 막는다.
 export function useLogoutMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: logout,
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.removeQueries({ queryKey: queryKeys.user.all });
     },
   });

--- a/src/hooks/use-logout-mutation.ts
+++ b/src/hooks/use-logout-mutation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { logout } from "@/api/user";
+
+// 로그아웃. logout()이 서버 호출 성공/실패와 무관하게 토큰을 정리한다(api/user.ts의 finally).
+// 성공 시 캐시된 user 쿼리를 제거해 로그아웃 상태에서 재조회(401)를 막는다.
+export function useLogoutMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: queryKeys.user.all });
+    },
+  });
+}

--- a/src/hooks/use-signup-mutation.ts
+++ b/src/hooks/use-signup-mutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { login, signUp } from "@/api/user";
+import type { UserSignUpRequest } from "@/types/user";
+
+// 회원가입 → 자동 로그인(S-03). signUp은 토큰을 안 주므로 같은 자격증명으로 login을 이어 호출한다.
+// 성공 시 토큰이 저장되므로 user 관련 쿼리를 무효화해 재조회하게 한다.
+export function useSignupMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: UserSignUpRequest) => {
+      await signUp(body);
+      await login({ email: body.email, password: body.password });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.all });
+    },
+  });
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -13,6 +13,22 @@ export interface UserLoginRequest {
   password: string;
 }
 
+// 약관 코드(swagger AgreementRequest.termCode enum).
+export type TermCode = "TERMS_OF_SERVICE" | "PRIVACY" | "AGE_14";
+
+export interface AgreementRequest {
+  termCode: TermCode;
+  agreed: boolean;
+}
+
+// 회원가입 요청(swagger SignUpRequest). 성공 시 바디·토큰 없음(200) → 이어서 login 호출.
+export interface UserSignUpRequest {
+  email: string;
+  nickname: string;
+  password: string;
+  agreements: AgreementRequest[];
+}
+
 // `GET /user/me` 서버 응답(swagger UserProfileResponse, camelCase).
 export interface UserProfileResponse {
   userId: number;


### PR DESCRIPTION
## 🎯 작업 내용

로그인·회원가입·로그아웃 화면을 백엔드에 연동했습니다. dev-token 우회를 걷어내고 토큰 저장 → 자동 로그인 → 로그아웃까지 실동작합니다.

## 📝 변경 사항

### `POST /user/login` — 로그인

- `src/hooks/use-login-mutation.ts`
- `src/app/(auth)/login.tsx`

### `POST /user/signUp` — 회원가입

- `src/hooks/use-signup-mutation.ts`
- `src/app/(auth)/signup.tsx`

### `GET /user/check-email` — 이메일 중복 확인

- `src/hooks/use-check-email-mutation.ts`
- `src/app/(auth)/signup.tsx`

### `GET /user/check-nickname` — 닉네임 중복 확인

- `src/hooks/use-check-nickname-mutation.ts`
- `src/app/(auth)/signup.tsx`

### `POST /user/logout` — 로그아웃

- `src/hooks/use-logout-mutation.ts`
- `src/app/(main)/my.tsx`

## 🔗 관련 이슈

- Closes #22

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 실제 로그인 및 회원가입 기능을 제공합니다.
  * 회원가입 시 이메일·닉네임 중복 여부를 확인할 수 있습니다.
  * 필수 약관 동의와 입력값 확인을 통해 가입 가능 상태를 안내합니다.
  * 로그인·회원가입 완료 후 지도 화면으로 이동합니다.
  * 로그아웃 시 서버 세션을 정리하고 로그인 화면으로 이동합니다.

* **오류 처리**
  * 인증 실패, 중복 입력, 네트워크 오류를 화면 메시지와 알림으로 안내합니다.
  * 로그인 및 회원가입 진행 중에는 제출 상태를 표시합니다.
  * 로그아웃 요청이 실패해도 로컬 세션을 정리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->