### PR TITLE
[FEAT] 지도·가게 조회 API 연동

### DIFF
--- a/src/api/store.ts
+++ b/src/api/store.ts
@@ -1,0 +1,166 @@
+import { apiClient } from "@/api/client";
+import { API_ENDPOINTS } from "@/api/endpoints";
+import type { Category, PlaceStatus, Place, SizeKey } from "@/types/place";
+import type { Review, ReviewResponse } from "@/types/review";
+import type {
+  ServerStatus,
+  SizeCounts,
+  SizeStatusResponse,
+  StoreCardResponse,
+  StoreDetail,
+  StoreDetailResponse,
+} from "@/types/store";
+
+// store 도메인 단일 호출 함수. 서버 원본을 이 파일(경계)에서 앱 타입으로 매핑한다.
+
+// 서버 store type(문자열)을 앱 Category로 접는다. swagger에 enum이 없어
+// api-architecture.md 규약(PARK/CAFE/… → park/cafe/…)을 따른다.
+const TYPE_TO_CATEGORY: Record<string, Category> = {
+  PARK: "park",
+  CAFE: "cafe",
+  RESTAURANT: "restaurant",
+  SHOPPING: "shopping",
+};
+
+// 이미 경고한 type은 다시 안 찍는다(가게 수백 개면 같은 경고가 도배됨).
+const warnedTypes = new Set<string>();
+
+function mapCategory(type: string): Category {
+  const category = TYPE_TO_CATEGORY[type?.toUpperCase?.() ?? ""];
+  if (category) {
+    return category;
+  }
+  if (__DEV__ && !warnedTypes.has(type)) {
+    warnedTypes.add(type);
+    console.warn(`[store] 알 수 없는 type "${type}" → cafe 폴백`);
+  }
+  return "cafe";
+}
+
+const STATUS_MAP: Record<ServerStatus, PlaceStatus> = {
+  POSSIBLE: "allowed",
+  IMPOSSIBLE: "denied",
+  UNKNOWN: "unknown",
+};
+
+function sizeKeyOf(size: SizeStatusResponse["size"]): SizeKey {
+  return size === "SMALL_MEDIUM" ? "smallMedium" : "large";
+}
+
+// 크기별 상태 배열 → Record. 빠진 크기는 미확인(unknown)으로 채운다.
+function foldSizeStatus(
+  list: SizeStatusResponse[] | undefined,
+): Record<SizeKey, PlaceStatus> {
+  const result: Record<SizeKey, PlaceStatus> = {
+    smallMedium: "unknown",
+    large: "unknown",
+  };
+  for (const item of list ?? []) {
+    result[sizeKeyOf(item.size)] = STATUS_MAP[item.status] ?? "unknown";
+  }
+  return result;
+}
+
+function foldSizeCounts(list: SizeStatusResponse[] | undefined): SizeCounts {
+  const result: SizeCounts = {
+    smallMedium: { possible: 0, impossible: 0 },
+    large: { possible: 0, impossible: 0 },
+  };
+  for (const item of list ?? []) {
+    result[sizeKeyOf(item.size)] = {
+      possible: item.possibleCount ?? 0,
+      impossible: item.impossibleCount ?? 0,
+    };
+  }
+  return result;
+}
+
+function mapStoreCard(res: StoreCardResponse): Place {
+  return {
+    id: String(res.storeId),
+    name: res.storeName,
+    category: mapCategory(res.type),
+    location: res.address,
+    latitude: res.geog?.lat ?? 0,
+    longitude: res.geog?.lng ?? 0,
+    sizeStatus: foldSizeStatus(res.sizeStatus),
+  };
+}
+
+function mapStoreDetail(res: StoreDetailResponse): StoreDetail {
+  return {
+    id: String(res.storeId),
+    name: res.name,
+    category: mapCategory(res.type),
+    location: res.address,
+    latitude: res.geog?.lat ?? 0,
+    longitude: res.geog?.lng ?? 0,
+    sizeStatus: foldSizeStatus(res.sizeStatus),
+    // reviewCount는 서버에 없어 확인 리뷰(가능+불가) 합으로 파생한다.
+    reviewCount: (res.possibleCount ?? 0) + (res.impossibleCount ?? 0),
+    lastVerifiedAt: res.lastVerifiedAt ?? null,
+    tags: res.tags ?? [],
+    openTime: res.openTime ?? null,
+    closeTime: res.closeTime ?? null,
+    thumbnailUrls: res.thumbnailUrls ?? [],
+    sizeCounts: foldSizeCounts(res.sizeStatus),
+  };
+}
+
+export interface StoresQueryParams {
+  lat: number;
+  lng: number;
+  radius?: number;
+}
+
+export async function getStores(params: StoresQueryParams): Promise<Place[]> {
+  const { data } = await apiClient.get<StoreCardResponse[]>(
+    API_ENDPOINTS.store.list,
+    { params },
+  );
+  return data.map(mapStoreCard);
+}
+
+export async function searchStores(keyword: string): Promise<Place[]> {
+  const { data } = await apiClient.get<StoreCardResponse[]>(
+    API_ENDPOINTS.store.search,
+    { params: { keyword } },
+  );
+  return data.map(mapStoreCard);
+}
+
+export async function getStoreDetail(storeId: string): Promise<StoreDetail> {
+  const { data } = await apiClient.get<StoreDetailResponse>(
+    API_ENDPOINTS.store.detail(storeId),
+  );
+  return mapStoreDetail(data);
+}
+
+// 응답엔 placeId가 없어 요청한 storeId로 채운다(목·화면 연결용).
+function mapReview(res: ReviewResponse, storeId: string): Review {
+  return {
+    id: String(res.reviewId),
+    placeId: storeId,
+    nickname: res.nickname,
+    dogAllowed: res.dogAllowed,
+    dogSize: res.dogSize === "SMALL_MEDIUM" ? "smallMedium" : "large",
+    photoUrl: res.photoUrl ?? null,
+    thumbnailUrl: res.thumbnailUrl ?? null,
+    content: res.content ?? null,
+    tags: res.tags ?? [],
+    createdAt: res.createdAt,
+  };
+}
+
+// 가게 리뷰 목록(상세 최근 리뷰·전체보기). 최신순은 서버 정렬을 따른다.
+export async function getStoreReviews(
+  storeId: string,
+  page = 0,
+  size = 20,
+): Promise<Review[]> {
+  const { data } = await apiClient.get<ReviewResponse[]>(
+    API_ENDPOINTS.store.reviews(storeId),
+    { params: { page, size } },
+  );
+  return data.map((review) => mapReview(review, storeId));
+}

--- a/src/app/(main)/map.tsx
+++ b/src/app/(main)/map.tsx
@@ -14,8 +14,13 @@ import {
 } from "@/components/map/size-filter-dropdown";
 import { SearchBar } from "@/components/ui/search-bar";
 import { Palette, Radius, Spacing } from "@/constants/theme";
-import { MOCK_PLACES, MOCK_PLACE_KEYWORDS } from "@/mocks/places";
+import { useStoreSearchQuery } from "@/hooks/use-store-search-query";
+import { useStoresQuery } from "@/hooks/use-stores-query";
 import type { Place } from "@/types/place";
+
+// 핀 조회 중심점(서울숲) — place-map 초기 카메라와 맞춘다. 반경으로 핀 밀도 조절(MVP 고정).
+const MAP_CENTER = { lat: 37.5445, lng: 127.0374 };
+const MAP_RADIUS = 1000;
 
 export default function MapScreen() {
   const router = useRouter();
@@ -27,23 +32,16 @@ export default function MapScreen() {
   const keyword = query.trim();
   const isSearching = keyword.length > 0;
 
+  const storesQuery = useStoresQuery({ ...MAP_CENTER, radius: MAP_RADIUS });
+  const searchQuery = useStoreSearchQuery(query);
+
+  // 크기 필터는 클라에서 건다(서버 size 미사용) — 필터 규칙은 filterPlacesBySize 한 곳.
   const pins = useMemo(
-    () => filterPlacesBySize(MOCK_PLACES, sizeFilter),
-    [sizeFilter],
+    () => filterPlacesBySize(storesQuery.data ?? [], sizeFilter),
+    [storesQuery.data, sizeFilter],
   );
 
-  const results = useMemo(() => {
-    if (!isSearching) {
-      return [];
-    }
-    const lowered = keyword.toLowerCase();
-    return MOCK_PLACES.filter(
-      (place) =>
-        place.name.toLowerCase().includes(lowered) ||
-        // [DEV] 한글 자판 없이 영어로도 검색되게 하는 임시 매칭
-        (MOCK_PLACE_KEYWORDS[place.id] ?? "").includes(lowered),
-    );
-  }, [isSearching, keyword]);
+  const results = isSearching ? (searchQuery.data ?? []) : [];
 
   const selectPlace = (place: Place) => {
     Keyboard.dismiss();

--- a/src/app/store/[placeId]/index.tsx
+++ b/src/app/store/[placeId]/index.tsx
@@ -9,7 +9,13 @@ import {
   MessageCircleDashed,
   PawPrint,
 } from "lucide-react-native";
-import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { HashtagChipList } from "@/components/place/hashtag-chip";
@@ -19,12 +25,12 @@ import { ThemedText } from "@/components/themed-text";
 import { Button } from "@/components/ui/button";
 import { CATEGORY_LABEL } from "@/constants/category";
 import { Palette, Radius, Spacing } from "@/constants/theme";
-import { MOCK_PLACES } from "@/mocks/places";
-import { getPlaceTags, getRecentReviews } from "@/mocks/reviews";
+import { useStoreDetailQuery } from "@/hooks/use-store-detail-query";
+import { useStoreReviewsQuery } from "@/hooks/use-store-reviews-query";
 
 /**
  * 가게 상세(S-05) — 전체 화면 페이지. 지도 핀/검색 결과에서 진입한다.
- * 리뷰 쓰기 플로우(플로우 A)의 시작점. 데이터는 목(src/mocks).
+ * 리뷰 쓰기 플로우(플로우 A)의 시작점.
  */
 export default function StoreDetailScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
@@ -32,9 +38,19 @@ export default function StoreDetailScreen() {
   const insets = useSafeAreaInsets();
   const [saved, setSaved] = useState(false);
 
-  const place = MOCK_PLACES.find((item) => item.id === placeId);
+  const { data: place, isLoading, isError } = useStoreDetailQuery(placeId);
+  const reviewsQuery = useStoreReviewsQuery(placeId);
 
-  if (!place) {
+  if (isLoading) {
+    return (
+      <View style={[styles.root, styles.center]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <ActivityIndicator color={Palette.main[500]} />
+      </View>
+    );
+  }
+
+  if (isError || !place) {
     return (
       <View style={[styles.root, styles.center]}>
         <Stack.Screen options={{ headerShown: false }} />
@@ -45,8 +61,8 @@ export default function StoreDetailScreen() {
     );
   }
 
-  const reviews = getRecentReviews(place.id, 3);
-  const tags = getPlaceTags(place.id);
+  const reviews = (reviewsQuery.data ?? []).slice(0, 3);
+  const tags = place.tags;
   const coverUri = reviews.find((review) => review.photoUrl)?.photoUrl ?? null;
   const hasReviews = reviews.length > 0;
 
@@ -129,8 +145,11 @@ export default function StoreDetailScreen() {
             </View>
 
             <SizeStatusSection
-              placeId={place.id}
               sizeStatus={place.sizeStatus}
+              counts={{
+                smallMedium: place.sizeCounts.smallMedium.possible,
+                large: place.sizeCounts.large.possible,
+              }}
             />
           </View>
 

--- a/src/app/store/[placeId]/reviews.tsx
+++ b/src/app/store/[placeId]/reviews.tsx
@@ -6,8 +6,8 @@ import { ReviewCard } from "@/components/review/review-card";
 import { ThemedText } from "@/components/themed-text";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { Palette, Spacing } from "@/constants/theme";
-import { MOCK_PLACES } from "@/mocks/places";
-import { getPlaceReviews } from "@/mocks/reviews";
+import { useStoreDetailQuery } from "@/hooks/use-store-detail-query";
+import { useStoreReviewsQuery } from "@/hooks/use-store-reviews-query";
 
 /**
  * 리뷰 전체보기(NEW). 상세 시트의 [전체보기 >]로 진입하는 별도 화면.
@@ -18,8 +18,8 @@ export default function StoreReviewsScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
   const insets = useSafeAreaInsets();
 
-  const place = MOCK_PLACES.find((item) => item.id === placeId);
-  const reviews = getPlaceReviews(placeId ?? "");
+  const { data: place } = useStoreDetailQuery(placeId);
+  const reviews = useStoreReviewsQuery(placeId).data ?? [];
 
   return (
     <View style={styles.root}>

--- a/src/components/place/size-status-section.tsx
+++ b/src/components/place/size-status-section.tsx
@@ -6,18 +6,17 @@ import { Pressable, StyleSheet, View } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { SIZE_LABEL, STATUS_LABEL } from "@/constants/status";
 import { Palette, Radius, Spacing } from "@/constants/theme";
-import { getConfirmedCounts } from "@/mocks/reviews";
 import type { PlaceStatus, SizeKey } from "@/types/place";
 
 export function SizeStatusSection({
-  placeId,
   sizeStatus,
+  counts,
 }: {
-  placeId: string;
   sizeStatus: Record<SizeKey, PlaceStatus>;
+  /** 크기별 "동반 확인(가능)" 리뷰 수. 상세 응답 sizeCounts.possible에서 온다. */
+  counts: Record<SizeKey, number>;
 }) {
   const [open, setOpen] = useState(false);
-  const counts = getConfirmedCounts(placeId);
 
   const statusColor = (status: PlaceStatus) => Palette.status[status][300];
 

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -2,10 +2,11 @@ import type { Category } from "@/types/place";
 
 /**
  * 업종 표시 라벨. 검색 결과·가게 상세 등 UI 공통으로 쓴다.
- * 백엔드 enum(`park`/`cafe`/`restaurant`)과 1:1 대응.
+ * 백엔드 enum(`park`/`cafe`/`restaurant`/`shopping`)과 1:1 대응.
  */
 export const CATEGORY_LABEL: Record<Category, string> = {
   park: "공원·산책로",
   cafe: "카페",
   restaurant: "식당",
+  shopping: "쇼핑",
 };

--- a/src/hooks/use-debounced-value.ts
+++ b/src/hooks/use-debounced-value.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+// 값이 delay(ms) 동안 안 바뀌면 그때 반영한다. 검색 입력 → 네트워크 호출 사이 완충용.
+export function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/hooks/use-store-detail-query.ts
+++ b/src/hooks/use-store-detail-query.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getStoreDetail } from "@/api/store";
+
+export function useStoreDetailQuery(storeId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.store.detail(storeId ?? ""),
+    queryFn: () => getStoreDetail(storeId as string),
+    enabled: Boolean(storeId),
+  });
+}

--- a/src/hooks/use-store-reviews-query.ts
+++ b/src/hooks/use-store-reviews-query.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getStoreReviews } from "@/api/store";
+
+export function useStoreReviewsQuery(storeId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.store.reviews(storeId ?? ""),
+    queryFn: () => getStoreReviews(storeId as string),
+    enabled: Boolean(storeId),
+  });
+}

--- a/src/hooks/use-store-search-query.ts
+++ b/src/hooks/use-store-search-query.ts
@@ -1,0 +1,19 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { searchStores } from "@/api/store";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+
+// 화면 단 훅: 가게명 검색. 입력을 디바운스하고, 빈 검색어면 호출하지 않는다.
+// 타이핑 중 결과가 깜빡이지 않게 이전 데이터를 유지한다.
+export function useStoreSearchQuery(keyword: string) {
+  const debounced = useDebouncedValue(keyword.trim(), 300);
+  const enabled = debounced.length > 0;
+
+  return useQuery({
+    queryKey: queryKeys.store.search(debounced),
+    queryFn: () => searchStores(debounced),
+    enabled,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/src/hooks/use-stores-query.ts
+++ b/src/hooks/use-stores-query.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getStores, type StoresQueryParams } from "@/api/store";
+
+export function useStoresQuery(params: StoresQueryParams) {
+  return useQuery({
+    queryKey: queryKeys.store.list(params),
+    queryFn: () => getStores(params),
+  });
+}

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -16,6 +16,7 @@ export interface Place {
   latitude: number;
   longitude: number;
   sizeStatus: Record<SizeKey, PlaceStatus>;
-  reviewCount: number;
-  lastVerifiedAt: string | null;
+  /** 카드(목록·검색) 응답엔 없다 — 상세(StoreDetail)에서만 채운다. */
+  reviewCount?: number;
+  lastVerifiedAt?: string | null;
 }

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -5,7 +5,7 @@
 
 export type SizeKey = "smallMedium" | "large";
 export type PlaceStatus = "allowed" | "denied" | "unknown";
-export type Category = "park" | "cafe" | "restaurant";
+export type Category = "park" | "cafe" | "restaurant" | "shopping";
 
 export interface Place {
   id: string;

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -7,6 +7,20 @@
  */
 import type { SizeKey } from "@/types/place";
 
+// 서버 응답 DTO(`GET /stores/{storeId}/reviews`의 ReviewResponse). 경계에서 Review로 매핑한다.
+// placeId는 응답에 없어 경로 파라미터(storeId)로 채운다.
+export interface ReviewResponse {
+  reviewId: number;
+  nickname: string;
+  dogAllowed: boolean;
+  dogSize: "SMALL_MEDIUM" | "LARGE";
+  photoUrl: string | null;
+  thumbnailUrl: string | null;
+  tags: string[];
+  content: string | null;
+  createdAt: string;
+}
+
 export interface Review {
   id: string;
   placeId: string;

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,0 +1,71 @@
+/**
+ * store 도메인 API 스펙(swagger `/v3/api-docs` 기준). 지도 핀(S-04)·검색·상세(S-05).
+ * 임의로 바꾸지 말 것 — 바꾸려면 백엔드 담당과 먼저 합의한다.
+ * 서버 원본은 경계(`src/api/store.ts`)에서 앱 타입(camelCase·enum)으로 매핑한다.
+ */
+import type { Place, SizeKey } from "@/types/place";
+
+// ── 서버 응답 DTO ──────────────────────────────────────────
+
+/** 좌표. 앱에선 latitude/longitude로 편다. */
+export interface GeoPoint {
+  lat: number;
+  lng: number;
+}
+
+export type ServerSize = "SMALL_MEDIUM" | "LARGE";
+export type ServerStatus = "POSSIBLE" | "IMPOSSIBLE" | "UNKNOWN";
+
+/** 크기별 상태 한 줄. 응답은 이 객체의 배열로 온다(앱에선 Record로 접는다). */
+export interface SizeStatusResponse {
+  size: ServerSize;
+  status: ServerStatus;
+  possibleCount: number;
+  impossibleCount: number;
+}
+
+/** `GET /stores`·`GET /stores/search`의 카드 응답. */
+export interface StoreCardResponse {
+  storeId: number;
+  storeName: string;
+  geog: GeoPoint;
+  address: string;
+  type: string;
+  sizeStatus: SizeStatusResponse[];
+}
+
+/** `GET /stores/{storeId}`의 상세 응답(카드 필드 + 상세 전용). */
+export interface StoreDetailResponse {
+  storeId: number;
+  name: string;
+  geog: GeoPoint;
+  address: string;
+  type: string;
+  tags: string[];
+  openTime: string | null;
+  closeTime: string | null;
+  possibleCount: number;
+  impossibleCount: number;
+  lastVerifiedAt: string | null;
+  sizeStatus: SizeStatusResponse[];
+  thumbnailUrls: string[];
+}
+
+// ── 앱 타입 ────────────────────────────────────────────────
+
+/** 크기별 확인 리뷰 수(상세 sizeStatus에서 접음). */
+export type SizeCounts = Record<
+  SizeKey,
+  { possible: number; impossible: number }
+>;
+
+/** 가게 상세(S-05). 카드(Place) + 상세 전용 필드를 더한 형태. */
+export interface StoreDetail extends Place {
+  reviewCount: number;
+  lastVerifiedAt: string | null;
+  tags: string[];
+  openTime: string | null;
+  closeTime: string | null;
+  thumbnailUrls: string[];
+  sizeCounts: SizeCounts;
+}


### PR DESCRIPTION
## 🎯 작업 내용

지도 핀(S-04)·가게명 검색·가게 상세(S-05)를 백엔드에 연동했습니다. 목 데이터(`src/mocks/places`) 의존을 걷어내고 지도 핀 → 검색 → 상세 → 리뷰까지 실 API로 동작합니다.

서버 응답은 도메인 함수 경계(`src/api/store.ts`)에서 앱 타입으로 매핑합니다: `geog{lat,lng}→latitude/longitude`, `type→category`, `sizeStatus[]→Record`, 상태 `POSSIBLE/IMPOSSIBLE/UNKNOWN→allowed/denied/unknown`.

> ⚠️ **추후 연동 필요:** 가게 상세의 **크기별(소·중형견/대형견) 리뷰 확인 카운트**(`sizeStatus[].possibleCount/impossibleCount` → 상세 화면 "확인 N건")는 **백엔드 미구현**입니다. 프론트는 응답값 매핑까지 붙여놨고, 서버가 값을 채워주면 재검증만 하면 됩니다.

## 📝 변경 사항

### `GET /stores` — 지도 핀 

- `src/hooks/use-stores-query.ts`
- `src/app/(main)/map.tsx` (서울숲 중심·반경 1km, 크기 필터는 클라 처리)

### `GET /stores/search` — 가게명 검색

- `src/hooks/use-debounced-value.ts` (300ms 디바운스)
- `src/hooks/use-store-search-query.ts`
- `src/app/(main)/map.tsx`

### `GET /stores/{storeId}` — 가게 상세

- `src/hooks/use-store-detail-query.ts`
- `src/app/store/[placeId]/index.tsx`
- `src/components/place/size-status-section.tsx` (확인 카운트 목→응답값)

### `GET /stores/{storeId}/reviews` — 가게 리뷰 (최근·전체보기)

- `src/hooks/use-store-reviews-query.ts`
- `src/app/store/[placeId]/index.tsx` (최근 리뷰)
- `src/app/store/[placeId]/reviews.tsx` (전체보기)

### 공통 레이어

- `src/api/store.ts` — 도메인 호출 함수 + 응답 경계 매핑
- `src/types/store.ts` · `src/types/review.ts` — 서버 DTO·앱 타입
- `src/types/place.ts` — 카드 응답엔 없는 `reviewCount`/`lastVerifiedAt` optional 완화
- `src/constants/category.ts` — `shopping` 카테고리 추가 (서버 type 반영)

## 🔗 관련 이슈

- Closes #24

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음 (HTTP cleartext 허용은 기존 설정, 신규 의존성·env 변경 없음)

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android — 에뮬레이터에서 핀·검색·상세·리뷰 4종 `200` 확인

## 📸 스크린샷 / 화면 녹화

<!-- 지도 핀·검색 결과·가게 상세 캡처 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 실제 매장 데이터를 기반으로 지도에서 매장 목록과 검색 결과를 확인할 수 있습니다.
  - 매장 상세 정보와 리뷰를 서버에서 조회합니다.
  - 매장 크기별 이용 가능 상태와 확인된 리뷰 수를 표시합니다.
  - 검색어 입력 시 지연 처리로 더욱 안정적인 검색을 제공합니다.
  - 쇼핑 카테고리를 지원합니다.

- **개선**
  - 데이터 로딩 중 진행 상태를 표시하고, 조회 실패 시 오류 화면을 제공합니다.
  - 매장 및 리뷰 정보가 없을 때도 안정적으로 화면을 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->