### PR TITLE
[FEAT] 리뷰 API 연동 (내 리뷰 목록·삭제·신고)

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -26,6 +26,7 @@ export const API_ENDPOINTS = {
     base: "/reviews", // POST 등록
     receiptVerify: "/reviews/receipt-verify",
     detail: (reviewId: string) => `/reviews/${reviewId}`, // DELETE
+    reports: (reviewId: string) => `/reviews/${reviewId}/reports`, // POST 신고
     tags: "/tags",
   },
   course: {

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,0 +1,54 @@
+import { apiClient } from "@/api/client";
+import { API_ENDPOINTS } from "@/api/endpoints";
+import { mapCategory } from "@/api/store";
+import type {
+  MyReview,
+  MyReviewResponse,
+  ReviewReportRequest,
+} from "@/types/review";
+
+// review 도메인 단일 호출 함수. 서버 원본을 이 파일(경계)에서 앱 타입으로 매핑한다.
+
+// 데모 기간에는 조회에 demo=true를 붙인다(store 도메인과 동일 규약).
+const DEMO_MODE = true;
+
+// 내가 쓴 리뷰(`GET /user/me/reviews`)는 store 정보를 직접 내려주므로 목 place 조회가 필요 없다.
+function mapMyReview(res: MyReviewResponse): MyReview {
+  return {
+    id: String(res.reviewId),
+    storeId: String(res.storeId),
+    storeName: res.storeName,
+    category: mapCategory(res.type),
+    dogAllowed: res.dogAllowed,
+    dogSize: res.dogSize === "SMALL_MEDIUM" ? "smallMedium" : "large",
+    photoUrl: res.photoUrl ?? null,
+    thumbnailUrl: res.thumbnailUrl ?? null,
+    createdAt: res.createdAt,
+  };
+}
+
+// 내 리뷰 목록. 받은 수가 size와 같으면 다음 페이지가 있다고 본다(서버에 total 없음).
+export async function getMyReviewsPage(
+  page = 0,
+  size = 20,
+): Promise<MyReview[]> {
+  const { data } = await apiClient.get<MyReviewResponse[]>(
+    API_ENDPOINTS.user.myReviews,
+    { params: { page, size, demo: DEMO_MODE } },
+  );
+  return data.map(mapMyReview);
+}
+
+// 리뷰 삭제(마이 리뷰·가게 전체리뷰 공통). 성공 시 바디 없음.
+export async function deleteReview(reviewId: string): Promise<void> {
+  await apiClient.delete(API_ENDPOINTS.review.detail(reviewId));
+}
+
+// 리뷰 신고. 성공(201) 시 바디 없음.
+export async function reportReview(
+  reviewId: string,
+  reason: string,
+): Promise<void> {
+  const body: ReviewReportRequest = { reason };
+  await apiClient.post(API_ENDPOINTS.review.reports(reviewId), body);
+}

--- a/src/api/store.ts
+++ b/src/api/store.ts
@@ -25,7 +25,8 @@ const TYPE_TO_CATEGORY: Record<string, Category> = {
 // 이미 경고한 type은 다시 안 찍는다(가게 수백 개면 같은 경고가 도배됨).
 const warnedTypes = new Set<string>();
 
-function mapCategory(type: string): Category {
+// 서버 store type → 앱 Category. review 도메인(마이 리뷰)에서도 재사용한다.
+export function mapCategory(type: string): Category {
   const category = TYPE_TO_CATEGORY[type?.toUpperCase?.() ?? ""];
   if (category) {
     return category;

--- a/src/app/my/reviews.tsx
+++ b/src/app/my/reviews.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 
-import {
-  useInfiniteQuery,
-  useQueryClient,
-  type InfiniteData,
-} from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { MessageCircleDashed, Trash2 } from "lucide-react-native";
 import {
@@ -25,19 +21,9 @@ import { LoadingView } from "@/components/ui/loading-view";
 import { PopoverMenu, type MenuAnchor } from "@/components/ui/popover-menu";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { Palette, Spacing } from "@/constants/theme";
-import { MOCK_PLACES } from "@/mocks/places";
-import { getMyReviews } from "@/mocks/reviews";
-import type { Review } from "@/types/review";
-
-const PLACE_BY_ID = new Map(MOCK_PLACES.map((place) => [place.id, place]));
-
-// TODO(api): 백엔드 `GET /user/me/reviews` 연동 시 이 목 페이저를 실제 호출로 교체한다.
-const PAGE_SIZE = 10;
-
-function fetchMyReviewsPage(page: number): Review[] {
-  const all = getMyReviews();
-  return all.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
-}
+import { useDeleteReviewMutation } from "@/hooks/use-delete-review-mutation";
+import { useMyReviewsQuery } from "@/hooks/use-my-reviews-query";
+import type { MyReview } from "@/types/review";
 
 type DeleteMenu = { anchor: MenuAnchor; reviewId: string };
 
@@ -48,18 +34,13 @@ export default function MyReviewsScreen() {
 
   const [menu, setMenu] = useState<DeleteMenu | null>(null);
 
-  const reviewsQuery = useInfiniteQuery({
-    queryKey: queryKeys.user.myReviews(),
-    queryFn: ({ pageParam }) => fetchMyReviewsPage(pageParam),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
+  const reviewsQuery = useMyReviewsQuery();
+  const deleteMutation = useDeleteReviewMutation();
 
   const reviews = reviewsQuery.data?.pages.flat() ?? [];
 
-  const openStore = (placeId: string) =>
-    router.push({ pathname: "/store/[placeId]", params: { placeId } });
+  const openStore = (storeId: string) =>
+    router.push({ pathname: "/store/[placeId]", params: { placeId: storeId } });
 
   const deleteActive = () => {
     if (!menu) {
@@ -67,7 +48,8 @@ export default function MyReviewsScreen() {
     }
     const { reviewId } = menu;
     setMenu(null);
-    queryClient.setQueryData<InfiniteData<Review[], number>>(
+    // 낙관적 제거: 성공 응답 전에 목록에서 먼저 지운다. 실패 시 onError에서 되돌린다.
+    queryClient.setQueryData<InfiniteData<MyReview[], number>>(
       queryKeys.user.myReviews(),
       (old) =>
         old
@@ -79,7 +61,19 @@ export default function MyReviewsScreen() {
             }
           : old,
     );
-    ToastAndroid.show("리뷰를 삭제했어요", ToastAndroid.SHORT);
+    deleteMutation.mutate(
+      { reviewId },
+      {
+        onSuccess: () =>
+          ToastAndroid.show("리뷰를 삭제했어요", ToastAndroid.SHORT),
+        onError: () => {
+          ToastAndroid.show("삭제하지 못했어요", ToastAndroid.SHORT);
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.user.myReviews(),
+          });
+        },
+      },
+    );
   };
 
   if (reviewsQuery.isLoading) {
@@ -141,22 +135,15 @@ export default function MyReviewsScreen() {
             />
           ) : null
         }
-        renderItem={({ item }) => {
-          const place = PLACE_BY_ID.get(item.placeId);
-          if (!place) {
-            return null;
-          }
-          return (
-            <MyReviewItem
-              review={item}
-              place={place}
-              onPress={openStore}
-              onMenu={(review, anchor) =>
-                setMenu({ anchor, reviewId: review.id })
-              }
-            />
-          );
-        }}
+        renderItem={({ item }) => (
+          <MyReviewItem
+            review={item}
+            onPress={openStore}
+            onMenu={(review, anchor) =>
+              setMenu({ anchor, reviewId: review.id })
+            }
+          />
+        )}
         ListEmptyComponent={
           <EmptyState
             Icon={MessageCircleDashed}

--- a/src/app/my/reviews.tsx
+++ b/src/app/my/reviews.tsx
@@ -48,7 +48,11 @@ export default function MyReviewsScreen() {
     }
     const { reviewId } = menu;
     setMenu(null);
-    // 낙관적 제거: 성공 응답 전에 목록에서 먼저 지운다. 실패 시 onError에서 되돌린다.
+    // 낙관적 제거: 성공 응답 전에 목록에서 먼저 지운다.
+    // 실패하면 재조회가 아니라 이 스냅샷으로 정확히 되돌린다(재조회도 실패하는 경우 대비).
+    const previous = queryClient.getQueryData<InfiniteData<MyReview[], number>>(
+      queryKeys.user.myReviews(),
+    );
     queryClient.setQueryData<InfiniteData<MyReview[], number>>(
       queryKeys.user.myReviews(),
       (old) =>
@@ -68,9 +72,9 @@ export default function MyReviewsScreen() {
           ToastAndroid.show("리뷰를 삭제했어요", ToastAndroid.SHORT),
         onError: () => {
           ToastAndroid.show("삭제하지 못했어요", ToastAndroid.SHORT);
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.user.myReviews(),
-          });
+          if (previous) {
+            queryClient.setQueryData(queryKeys.user.myReviews(), previous);
+          }
         },
       },
     );

--- a/src/app/store/[placeId]/reviews.tsx
+++ b/src/app/store/[placeId]/reviews.tsx
@@ -20,6 +20,8 @@ import { LoadingView } from "@/components/ui/loading-view";
 import { PopoverMenu, type MenuAnchor } from "@/components/ui/popover-menu";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { Palette, Spacing } from "@/constants/theme";
+import { useDeleteReviewMutation } from "@/hooks/use-delete-review-mutation";
+import { useReportReviewMutation } from "@/hooks/use-report-review-mutation";
 import { useStoreDetailQuery } from "@/hooks/use-store-detail-query";
 import { useStoreReviewsQuery } from "@/hooks/use-store-reviews-query";
 
@@ -28,7 +30,7 @@ type ReviewMenu = { anchor: MenuAnchor; reviewId: string; mine: boolean };
 /**
  * 리뷰 전체보기(NEW). 상세 시트의 [전체보기 >]로 진입하는 별도 화면.
  * 무한스크롤로 모든 리뷰를 이어붙여 보여준다.
- * 각 리뷰의 ⋯ → 본인 리뷰면 삭제, 남의 리뷰면 신고(신고 API 미구현: 접수 안내만).
+ * 각 리뷰의 ⋯ → 본인 리뷰(mine)면 삭제, 남의 리뷰면 신고. 둘 다 실 API 연동.
  */
 export default function StoreReviewsScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
@@ -36,24 +38,58 @@ export default function StoreReviewsScreen() {
 
   const { data: place } = useStoreDetailQuery(placeId);
   const reviewsQuery = useStoreReviewsQuery(placeId);
+  const deleteMutation = useDeleteReviewMutation();
+  const reportMutation = useReportReviewMutation();
 
   const [menu, setMenu] = useState<ReviewMenu | null>(null);
   const [reportOpen, setReportOpen] = useState(false);
+  // 신고 대상 reviewId — 메뉴를 닫은 뒤 모달 제출까지 유지해야 하므로 별도 보관.
+  const [reportTarget, setReportTarget] = useState<string | null>(null);
 
   const reviews = reviewsQuery.data?.pages.flat() ?? [];
 
   const openReport = () => {
+    if (!menu) {
+      return;
+    }
+    setReportTarget(menu.reviewId);
     setMenu(null);
     setReportOpen(true);
   };
 
-  const submitReport = () => {
+  const submitReport = (reason: string) => {
+    if (!reportTarget) {
+      return;
+    }
+    const reviewId = reportTarget;
     setReportOpen(false);
-    ToastAndroid.show("신고가 접수됐어요", ToastAndroid.SHORT);
+    setReportTarget(null);
+    reportMutation.mutate(
+      { reviewId, reason },
+      {
+        onSuccess: () =>
+          ToastAndroid.show("신고가 접수됐어요", ToastAndroid.SHORT),
+        onError: () =>
+          ToastAndroid.show("신고하지 못했어요", ToastAndroid.SHORT),
+      },
+    );
   };
 
   const openDelete = () => {
+    if (!menu) {
+      return;
+    }
+    const { reviewId } = menu;
     setMenu(null);
+    deleteMutation.mutate(
+      { reviewId, storeId: placeId },
+      {
+        onSuccess: () =>
+          ToastAndroid.show("리뷰를 삭제했어요", ToastAndroid.SHORT),
+        onError: () =>
+          ToastAndroid.show("삭제하지 못했어요", ToastAndroid.SHORT),
+      },
+    );
   };
 
   if (reviewsQuery.isLoading) {
@@ -165,7 +201,10 @@ export default function StoreReviewsScreen() {
 
       <ReportModal
         visible={reportOpen}
-        onClose={() => setReportOpen(false)}
+        onClose={() => {
+          setReportOpen(false);
+          setReportTarget(null);
+        }}
         onSubmit={submitReport}
       />
     </View>

--- a/src/components/review/my-review-item.tsx
+++ b/src/components/review/my-review-item.tsx
@@ -10,20 +10,17 @@ import { type MenuAnchor } from "@/components/ui/popover-menu";
 import { CATEGORY_LABEL } from "@/constants/category";
 import { SIZE_LABEL } from "@/constants/status";
 import { Palette, Radius, Spacing } from "@/constants/theme";
-import type { Place } from "@/types/place";
-import type { Review } from "@/types/review";
+import type { MyReview } from "@/types/review";
 import { formatMonthDay } from "@/utils/date";
 
 export function MyReviewItem({
   review,
-  place,
   onPress,
   onMenu,
 }: {
-  review: Review;
-  place: Place;
-  onPress: (placeId: string) => void;
-  onMenu?: (review: Review, anchor: MenuAnchor) => void;
+  review: MyReview;
+  onPress: (storeId: string) => void;
+  onMenu?: (review: MyReview, anchor: MenuAnchor) => void;
 }) {
   const thumbnail = review.thumbnailUrl ?? review.photoUrl;
   const menuRef = useRef<View>(null);
@@ -36,7 +33,7 @@ export function MyReviewItem({
 
   return (
     <Pressable
-      onPress={() => onPress(place.id)}
+      onPress={() => onPress(review.storeId)}
       accessibilityRole="button"
       style={({ pressed }) => [styles.item, pressed && styles.pressed]}
     >
@@ -46,7 +43,7 @@ export function MyReviewItem({
           style={styles.thumbnail}
           contentFit="cover"
           transition={150}
-          accessibilityLabel={`${place.name} 리뷰 사진`}
+          accessibilityLabel={`${review.storeName} 리뷰 사진`}
         />
       ) : null}
 
@@ -59,10 +56,10 @@ export function MyReviewItem({
         </View>
 
         <ThemedText type="subtitle03" color={Palette.gray[700]}>
-          {place.name}
+          {review.storeName}
         </ThemedText>
         <ThemedText type="label05" color={Palette.gray[400]}>
-          {CATEGORY_LABEL[place.category]} · {SIZE_LABEL[review.dogSize]}
+          {CATEGORY_LABEL[review.category]} · {SIZE_LABEL[review.dogSize]}
         </ThemedText>
       </View>
 
@@ -72,7 +69,7 @@ export function MyReviewItem({
           onPress={openMenu}
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel={`${place.name} 리뷰 더보기`}
+          accessibilityLabel={`${review.storeName} 리뷰 더보기`}
           style={styles.menuButton}
         >
           <MoreVertical

--- a/src/hooks/use-delete-review-mutation.ts
+++ b/src/hooks/use-delete-review-mutation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { deleteReview } from "@/api/review";
+
+type DeleteReviewVariables = {
+  reviewId: string;
+  /** 가게 전체리뷰에서 삭제할 때만 전달 — 해당 가게 리뷰·상세 캐시를 함께 무효화한다. */
+  storeId?: string;
+};
+
+/**
+ * 리뷰 삭제(`DELETE /reviews/{reviewId}`) 뮤테이션. 마이 리뷰·가게 전체리뷰 공통.
+ * 성공 시 내 리뷰 목록을 무효화하고, storeId가 오면 그 가게 리뷰·상세도 무효화한다.
+ * (마이 리뷰 화면은 즉시 반영을 위해 낙관적 제거를 별도로 수행한다.)
+ */
+export function useDeleteReviewMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ reviewId }: DeleteReviewVariables) => deleteReview(reviewId),
+    onSuccess: (_data, { storeId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.myReviews() });
+      if (storeId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.store.reviews(storeId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.store.detail(storeId),
+        });
+      }
+    },
+  });
+}

--- a/src/hooks/use-my-reviews-query.ts
+++ b/src/hooks/use-my-reviews-query.ts
@@ -1,0 +1,22 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getMyReviewsPage } from "@/api/review";
+
+/** 내 리뷰 페이지 크기. hasNext 판정(받은 수 === size)에 함께 쓴다. */
+export const MY_REVIEWS_PAGE_SIZE = 20;
+
+/**
+ * 내가 쓴 리뷰 무한스크롤 조회(`GET /user/me/reviews`).
+ * 받은 수가 페이지 크기와 같으면 다음 페이지가 있다고 본다(서버에 total이 없음).
+ */
+export function useMyReviewsQuery() {
+  return useInfiniteQuery({
+    queryKey: queryKeys.user.myReviews(),
+    queryFn: ({ pageParam }) =>
+      getMyReviewsPage(pageParam, MY_REVIEWS_PAGE_SIZE),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === MY_REVIEWS_PAGE_SIZE ? allPages.length : undefined,
+  });
+}

--- a/src/hooks/use-report-review-mutation.ts
+++ b/src/hooks/use-report-review-mutation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { reportReview } from "@/api/review";
+
+type ReportReviewVariables = {
+  reviewId: string;
+  reason: string;
+};
+
+/**
+ * 리뷰 신고(`POST /reviews/{reviewId}/reports`) 뮤테이션.
+ * 성공(201) 시 바디가 없어 캐시 변경은 없고, 화면에서 접수 안내만 한다.
+ */
+export function useReportReviewMutation() {
+  return useMutation({
+    mutationFn: ({ reviewId, reason }: ReportReviewVariables) =>
+      reportReview(reviewId, reason),
+  });
+}

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -5,7 +5,7 @@
  * - tags: 리뷰별 해시태그. 백엔드 응답 추가 요청 중(현재 스펙 미포함).
  * 임의로 바꾸지 말 것 — 바꾸려면 백엔드 담당과 먼저 합의한다.
  */
-import type { SizeKey } from "@/types/place";
+import type { Category, SizeKey } from "@/types/place";
 
 // 서버 응답 DTO(`GET /stores/{storeId}/reviews`의 ReviewResponse). 경계에서 Review로 매핑한다.
 // placeId는 응답에 없어 경로 파라미터(storeId)로 채운다.
@@ -39,4 +39,38 @@ export interface Review {
   /** ISO 8601 */
   createdAt: string;
   mine: boolean;
+}
+
+// 서버 응답 DTO(`GET /user/me/reviews`의 MyReviewResponse). 경계에서 MyReview로 매핑한다.
+// 가게 리뷰(ReviewResponse)와 달리 store 정보(storeId·storeName·type)를 직접 내려주고,
+// nickname·content·tags·mine은 없다(항상 본인 리뷰).
+export interface MyReviewResponse {
+  reviewId: string;
+  storeId: string;
+  storeName: string;
+  type: string;
+  dogAllowed: boolean;
+  dogSize: "SMALL_MEDIUM" | "LARGE";
+  photoUrl: string | null;
+  thumbnailUrl: string | null;
+  createdAt: string;
+}
+
+// 내가 쓴 리뷰(마이 리뷰 목록 아이템). store 정보를 응답에서 직접 받아 목 place 조회가 필요 없다.
+export interface MyReview {
+  id: string;
+  storeId: string;
+  storeName: string;
+  category: Category;
+  dogAllowed: boolean;
+  dogSize: SizeKey;
+  photoUrl: string | null;
+  thumbnailUrl: string | null;
+  createdAt: string;
+}
+
+// 리뷰 신고 요청 바디(`POST /reviews/{reviewId}/reports`의 ReviewReportRequest).
+export interface ReviewReportRequest {
+  /** 신고 사유(50자 이내). */
+  reason: string;
 }


### PR DESCRIPTION
## 🎯 작업 내용

내 리뷰 목록·리뷰 삭제·리뷰 신고를 백엔드에 연동했습니다. #26에서 UI만 있던 것을 실동작으로 완성했습니다. 조회에는 `demo=true`를 유지합니다.

## 📝 변경 사항

### `GET /user/me/reviews` — 내 리뷰 목록

- `src/api/review.ts`
- `src/hooks/use-my-reviews-query.ts`
- `src/app/my/reviews.tsx`

### `DELETE /reviews/{reviewId}` — 리뷰 삭제 (마이·가게 전체리뷰 공통)

- `src/hooks/use-delete-review-mutation.ts`
- `src/app/my/reviews.tsx`
- `src/app/store/[placeId]/reviews.tsx`

### `POST /reviews/{reviewId}/reports` — 리뷰 신고

- `src/api/endpoints.ts`
- `src/hooks/use-report-review-mutation.ts`
- `src/app/store/[placeId]/reviews.tsx`

### `ReviewResponse.mine` — 소유자별 렌더링 분기 검증

가게 전체리뷰에서 **본인 리뷰 → ⋯ 삭제**, **남의 리뷰 → ⋯ 신고** 로 메뉴가 갈리는 것을 실데이터로 확인했습니다.

> ⚠️ **추후 연동:** 마이리뷰 상단의 **전체 리뷰수**는 현재 로드된 개수(`reviews.length`) 표기입니다. `GET /user/me`의 `reviewCount`로 총 개수를 표기하는 작업은 **후속 리뷰에서 `GET /user/me` 연동과 함께 진행**합니다.

## 🔗 관련 이슈

- Closes #28

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android — 목록 `GET 200` · 삭제 `DELETE 200`(마이·가게) · 신고 `POST 201` · `mine` 분기 실데이터 확인

## 📸 스크린샷 / 화면 녹화

<!-- 마이리뷰 목록·삭제, 가게 전체리뷰 mine 분기(삭제/신고) 캡처 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 내가 작성한 리뷰를 페이지 단위로 불러오고, 목록을 스크롤하며 확인할 수 있습니다.
  - 내 리뷰를 삭제할 수 있으며, 삭제 결과에 따라 안내 메시지가 표시됩니다.
  - 다른 리뷰를 신고하고 신고 사유를 제출할 수 있습니다.
  - 리뷰 삭제 및 신고 처리 결과와 오류 상황을 토스트 메시지로 안내합니다.

- **개선**
  - 리뷰 목록에서 매장 정보와 리뷰 카테고리가 더 일관되게 표시됩니다.
  - 리뷰 이미지와 메뉴의 접근성 안내가 매장명에 맞게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->