### PR TITLE
[FEAT] 마이·장소 저장 API 연동

### DIFF
--- a/src/api/store.ts
+++ b/src/api/store.ts
@@ -142,6 +142,25 @@ export async function getStoreDetail(storeId: string): Promise<StoreDetail> {
   return mapStoreDetail(data);
 }
 
+// 저장한 장소 목록(`GET /user/store`). 응답은 지도 카드와 같은 StoreCardResponse[]라
+// mapStoreCard를 그대로 재사용한다.
+export async function getSavedStores(): Promise<Place[]> {
+  const { data } = await apiClient.get<StoreCardResponse[]>(
+    API_ENDPOINTS.user.savedStores,
+    { params: { demo: DEMO_MODE } },
+  );
+  return data.map(mapStoreCard);
+}
+
+// 장소 저장/해제(`POST`/`DELETE /stores/{storeId}/save`). 바디·응답 본문 없음.
+export async function saveStore(storeId: string): Promise<void> {
+  await apiClient.post(API_ENDPOINTS.store.save(storeId));
+}
+
+export async function unsaveStore(storeId: string): Promise<void> {
+  await apiClient.delete(API_ENDPOINTS.store.save(storeId));
+}
+
 // 응답엔 placeId가 없어 요청한 storeId로 채운다(목·화면 연결용).
 function mapReview(res: ReviewResponse, storeId: string): Review {
   return {

--- a/src/app/(main)/my.tsx
+++ b/src/app/(main)/my.tsx
@@ -12,15 +12,21 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Passport } from "@/components/my/passport";
 import { ProfileSummaryCard } from "@/components/my/profile-summary-card";
 import { ThemedText } from "@/components/themed-text";
+import { ErrorState } from "@/components/ui/error-state";
+import { LoadingView } from "@/components/ui/loading-view";
 import { Palette, Spacing } from "@/constants/theme";
+import { useDeleteAccountMutation } from "@/hooks/use-delete-account-mutation";
 import { useLogoutMutation } from "@/hooks/use-logout-mutation";
-import { MOCK_PASSPORT, MOCK_USER } from "@/mocks/user";
+import { useMyProfileQuery } from "@/hooks/use-my-profile-query";
+import { MOCK_PASSPORT } from "@/mocks/user";
 import type { PassportStamp } from "@/types/user";
 
 export default function MyScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const logoutMutation = useLogoutMutation();
+  const deleteAccountMutation = useDeleteAccountMutation();
+  const profileQuery = useMyProfileQuery();
 
   const openReviews = () => router.push("/my/reviews");
 
@@ -58,7 +64,20 @@ export default function MyScreen() {
         {
           text: "탈퇴",
           style: "destructive",
-          onPress: () => router.replace("/login"),
+          onPress: async () => {
+            try {
+              await deleteAccountMutation.mutateAsync();
+            } catch {
+              // 탈퇴 실패 시 계정·세션은 그대로 유지된다(deleteUser는 성공 뒤에만 토큰 정리).
+              ToastAndroid.show(
+                "탈퇴에 실패했어요. 잠시 후 다시 시도해주세요.",
+                ToastAndroid.SHORT,
+              );
+              return;
+            }
+            ToastAndroid.show("탈퇴가 완료됐어요.", ToastAndroid.SHORT);
+            router.replace("/login");
+          },
         },
       ],
     );
@@ -72,11 +91,21 @@ export default function MyScreen() {
       ]}
       showsVerticalScrollIndicator={false}
     >
-      <ProfileSummaryCard
-        user={MOCK_USER}
-        onPressReviews={openReviews}
-        onLogout={logout}
-      />
+      {profileQuery.isLoading ? (
+        <LoadingView style={styles.profileState} />
+      ) : profileQuery.isError || !profileQuery.data ? (
+        <ErrorState
+          message="프로필을 불러오지 못했어요"
+          onRetry={() => profileQuery.refetch()}
+          style={styles.profileState}
+        />
+      ) : (
+        <ProfileSummaryCard
+          user={profileQuery.data}
+          onPressReviews={openReviews}
+          onLogout={logout}
+        />
+      )}
 
       <View style={styles.passportSection}>
         <ThemedText type="subtitle02" color={Palette.gray[700]}>
@@ -112,6 +141,9 @@ const styles = StyleSheet.create({
     gap: Spacing.four,
     paddingHorizontal: Spacing.four,
     paddingBottom: Spacing.five,
+  },
+  profileState: {
+    minHeight: 148,
   },
   passportSection: {
     gap: Spacing.three,

--- a/src/app/(main)/saved.tsx
+++ b/src/app/(main)/saved.tsx
@@ -11,10 +11,14 @@ import {
   type MenuAnchor,
 } from "@/components/saved/saved-place-row";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { LoadingView } from "@/components/ui/loading-view";
 import { PopoverMenu } from "@/components/ui/popover-menu";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Palette, Spacing } from "@/constants/theme";
-import { MOCK_SAVED_COURSES, MOCK_SAVED_PLACES } from "@/mocks/saved";
+import { useSavedStoresQuery } from "@/hooks/use-saved-stores-query";
+import { useToggleSavedStoreMutation } from "@/hooks/use-toggle-saved-store-mutation";
+import { MOCK_SAVED_COURSES } from "@/mocks/saved";
 import type { SavedCoursePreview } from "@/types/course";
 import type { Place } from "@/types/place";
 
@@ -32,7 +36,9 @@ export default function SavedScreen() {
   const insets = useSafeAreaInsets();
 
   const [segment, setSegment] = useState<Segment>("place");
-  const [places, setPlaces] = useState<Place[]>(MOCK_SAVED_PLACES);
+  const savedStoresQuery = useSavedStoresQuery();
+  const toggleSaved = useToggleSavedStoreMutation();
+  const places = savedStoresQuery.data ?? [];
   const [courses, setCourses] =
     useState<SavedCoursePreview[]>(MOCK_SAVED_COURSES);
   const [menu, setMenu] = useState<ActiveMenu | null>(null);
@@ -54,7 +60,8 @@ export default function SavedScreen() {
       return;
     }
     if (menu.type === "place") {
-      setPlaces((prev) => prev.filter((item) => item.id !== menu.id));
+      // 저장 해제 — 목록 캐시는 뮤테이션이 낙관적으로 갱신한다.
+      toggleSaved.mutate({ storeId: menu.id, nextSaved: false });
     } else {
       setCourses((prev) => prev.filter((item) => item.id !== menu.id));
     }
@@ -77,7 +84,14 @@ export default function SavedScreen() {
       </View>
 
       {segment === "place" ? (
-        places.length > 0 ? (
+        savedStoresQuery.isLoading ? (
+          <LoadingView />
+        ) : savedStoresQuery.isError ? (
+          <ErrorState
+            message="저장한 장소를 불러오지 못했어요"
+            onRetry={() => savedStoresQuery.refetch()}
+          />
+        ) : places.length > 0 ? (
           <FlatList
             data={places}
             keyExtractor={(item) => item.id}

--- a/src/app/my/reviews.tsx
+++ b/src/app/my/reviews.tsx
@@ -22,8 +22,10 @@ import { PopoverMenu, type MenuAnchor } from "@/components/ui/popover-menu";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { Palette, Spacing } from "@/constants/theme";
 import { useDeleteReviewMutation } from "@/hooks/use-delete-review-mutation";
+import { useMyProfileQuery } from "@/hooks/use-my-profile-query";
 import { useMyReviewsQuery } from "@/hooks/use-my-reviews-query";
 import type { MyReview } from "@/types/review";
+import type { UserSummary } from "@/types/user";
 
 type DeleteMenu = { anchor: MenuAnchor; reviewId: string };
 
@@ -35,9 +37,12 @@ export default function MyReviewsScreen() {
   const [menu, setMenu] = useState<DeleteMenu | null>(null);
 
   const reviewsQuery = useMyReviewsQuery();
+  const profileQuery = useMyProfileQuery();
   const deleteMutation = useDeleteReviewMutation();
 
   const reviews = reviewsQuery.data?.pages.flat() ?? [];
+  // 총 리뷰수는 GET /user/me 기준(무한스크롤로 로드된 개수가 아님). 미로드 시 로드분으로 폴백.
+  const totalCount = profileQuery.data?.reviewCount ?? reviews.length;
 
   const openStore = (storeId: string) =>
     router.push({ pathname: "/store/[placeId]", params: { placeId: storeId } });
@@ -53,6 +58,10 @@ export default function MyReviewsScreen() {
     const previous = queryClient.getQueryData<InfiniteData<MyReview[], number>>(
       queryKeys.user.myReviews(),
     );
+    // 상단 총 리뷰수(GET /user/me)도 즉시 -1 반영하고, 실패 시 함께 되돌린다.
+    const previousProfile = queryClient.getQueryData<UserSummary>(
+      queryKeys.user.me(),
+    );
     queryClient.setQueryData<InfiniteData<MyReview[], number>>(
       queryKeys.user.myReviews(),
       (old) =>
@@ -65,6 +74,9 @@ export default function MyReviewsScreen() {
             }
           : old,
     );
+    queryClient.setQueryData<UserSummary>(queryKeys.user.me(), (old) =>
+      old ? { ...old, reviewCount: Math.max(0, old.reviewCount - 1) } : old,
+    );
     deleteMutation.mutate(
       { reviewId },
       {
@@ -74,6 +86,9 @@ export default function MyReviewsScreen() {
           ToastAndroid.show("삭제하지 못했어요", ToastAndroid.SHORT);
           if (previous) {
             queryClient.setQueryData(queryKeys.user.myReviews(), previous);
+          }
+          if (previousProfile) {
+            queryClient.setQueryData(queryKeys.user.me(), previousProfile);
           }
         },
       },
@@ -127,7 +142,7 @@ export default function MyReviewsScreen() {
               color={Palette.gray[400]}
               style={styles.summary}
             >
-              최신순 · {reviews.length}건
+              최신순 · {totalCount}건
             </ThemedText>
           ) : null
         }

--- a/src/app/store/[placeId]/index.tsx
+++ b/src/app/store/[placeId]/index.tsx
@@ -22,8 +22,10 @@ import { ErrorState } from "@/components/ui/error-state";
 import { LoadingView } from "@/components/ui/loading-view";
 import { CATEGORY_LABEL } from "@/constants/category";
 import { Palette, Radius, Spacing } from "@/constants/theme";
+import { useSavedStoresQuery } from "@/hooks/use-saved-stores-query";
 import { useStoreDetailQuery } from "@/hooks/use-store-detail-query";
 import { useStoreReviewsQuery } from "@/hooks/use-store-reviews-query";
+import { useToggleSavedStoreMutation } from "@/hooks/use-toggle-saved-store-mutation";
 
 /**
  * 가게 상세(S-05) — 전체 화면 페이지. 지도 핀/검색 결과에서 진입한다.
@@ -33,12 +35,24 @@ export default function StoreDetailScreen() {
   const { placeId } = useLocalSearchParams<{ placeId: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const [saved, setSaved] = useState(false);
   const [failedCoverUri, setFailedCoverUri] = useState<string | null>(null);
 
   const detailQuery = useStoreDetailQuery(placeId);
   const reviewsQuery = useStoreReviewsQuery(placeId);
+  const savedStoresQuery = useSavedStoresQuery();
+  const toggleSaved = useToggleSavedStoreMutation();
   const place = detailQuery.data;
+
+  // 저장 여부는 저장 목록 캐시에서 파생한다(상세 응답엔 saved 필드가 없음).
+  const saved =
+    savedStoresQuery.data?.some((item) => item.id === placeId) ?? false;
+
+  const toggleSave = () => {
+    if (!place) {
+      return;
+    }
+    toggleSaved.mutate({ storeId: place.id, nextSaved: !saved, place });
+  };
 
   if (detailQuery.isLoading) {
     return (
@@ -122,7 +136,7 @@ export default function StoreDetailScreen() {
               styles.saveButton,
               { top: insets.top + Spacing.two },
             ]}
-            onPress={() => setSaved((prev) => !prev)}
+            onPress={toggleSave}
             hitSlop={8}
             accessibilityRole="button"
             accessibilityLabel={saved ? "저장 해제" : "저장"}

--- a/src/hooks/use-delete-account-mutation.ts
+++ b/src/hooks/use-delete-account-mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteUser } from "@/api/user";
+
+// 회원 탈퇴(`DELETE /user/me`). deleteUser가 성공 시 토큰을 정리한다(api/user.ts).
+// 탈퇴가 끝나면 캐시를 통째로 비워 이전 사용자 데이터 재사용을 막는다.
+export function useDeleteAccountMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteUser,
+    onSuccess: () => {
+      queryClient.clear();
+    },
+  });
+}

--- a/src/hooks/use-delete-review-mutation.ts
+++ b/src/hooks/use-delete-review-mutation.ts
@@ -21,6 +21,8 @@ export function useDeleteReviewMutation() {
     mutationFn: ({ reviewId }: DeleteReviewVariables) => deleteReview(reviewId),
     onSuccess: (_data, { storeId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.user.myReviews() });
+      // 총 리뷰수(GET /user/me)도 함께 갱신 — 마이 리뷰 상단·프로필 카드가 이 값을 쓴다.
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });
       if (storeId) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.store.reviews(storeId),

--- a/src/hooks/use-delete-review-mutation.ts
+++ b/src/hooks/use-delete-review-mutation.ts
@@ -19,7 +19,9 @@ export function useDeleteReviewMutation() {
 
   return useMutation({
     mutationFn: ({ reviewId }: DeleteReviewVariables) => deleteReview(reviewId),
-    onSuccess: (_data, { storeId }) => {
+    // onSettled로 성공·실패 모두 재동기화한다. 동시 삭제 중 하나가 실패해 목록·총계가
+    // 이전 스냅샷으로 롤백된 뒤에도 서버 기준값으로 맞춰지도록(성공 때만 무효화하면 stale).
+    onSettled: (_data, _error, { storeId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.user.myReviews() });
       // 총 리뷰수(GET /user/me)도 함께 갱신 — 마이 리뷰 상단·프로필 카드가 이 값을 쓴다.
       queryClient.invalidateQueries({ queryKey: queryKeys.user.me() });

--- a/src/hooks/use-saved-stores-query.ts
+++ b/src/hooks/use-saved-stores-query.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getSavedStores } from "@/api/store";
+
+// 저장한 장소 목록. 저장 탭·가게 상세 ♡가 같은 캐시(queryKeys.user.savedStores)를 공유한다.
+export function useSavedStoresQuery(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.user.savedStores(),
+    queryFn: getSavedStores,
+    enabled: options.enabled ?? true,
+  });
+}

--- a/src/hooks/use-toggle-saved-store-mutation.ts
+++ b/src/hooks/use-toggle-saved-store-mutation.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ToastAndroid } from "react-native";
+
+import { queryKeys } from "@/api/query-keys";
+import { saveStore, unsaveStore } from "@/api/store";
+import type { Place } from "@/types/place";
+
+type ToggleSavedVariables = {
+  storeId: string;
+  /** 다음 상태(true=저장, false=해제). 현재 상태의 반대를 넘긴다. */
+  nextSaved: boolean;
+  /** 저장(add) 시 목록 캐시에 낙관적으로 끼워 넣을 카드. 가게 상세에서 전달한다. */
+  place?: Place;
+};
+
+/**
+ * 장소 저장/해제 토글(`POST`/`DELETE /stores/{storeId}/save`).
+ * 저장 목록 캐시를 낙관적으로 갱신하고, 실패하면 이전 캐시로 되돌린다(리뷰 삭제 패턴 준용).
+ * 저장 탭·가게 상세 ♡가 이 캐시를 공유하므로 한 곳에서 토글하면 양쪽이 함께 반영된다.
+ */
+export function useToggleSavedStoreMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ storeId, nextSaved }: ToggleSavedVariables) =>
+      nextSaved ? saveStore(storeId) : unsaveStore(storeId),
+    onMutate: async ({ storeId, nextSaved, place }) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.user.savedStores(),
+      });
+      const previous = queryClient.getQueryData<Place[]>(
+        queryKeys.user.savedStores(),
+      );
+      queryClient.setQueryData<Place[]>(
+        queryKeys.user.savedStores(),
+        (old = []) => {
+          if (nextSaved) {
+            if (!place || old.some((item) => item.id === storeId)) {
+              return old;
+            }
+            return [place, ...old];
+          }
+          return old.filter((item) => item.id !== storeId);
+        },
+      );
+      return { previous };
+    },
+    onSuccess: (_data, { nextSaved }) => {
+      ToastAndroid.show(
+        nextSaved ? "장소를 저장했어요" : "저장을 해제했어요",
+        ToastAndroid.SHORT,
+      );
+    },
+    onError: (_error, { nextSaved }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.user.savedStores(),
+          context.previous,
+        );
+      }
+      ToastAndroid.show(
+        nextSaved ? "저장하지 못했어요" : "해제하지 못했어요",
+        ToastAndroid.SHORT,
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.user.savedStores(),
+      });
+    },
+  });
+}

--- a/src/hooks/use-toggle-saved-store-mutation.ts
+++ b/src/hooks/use-toggle-saved-store-mutation.ts
@@ -52,7 +52,11 @@ export function useToggleSavedStoreMutation() {
       );
     },
     onError: (_error, { nextSaved }, context) => {
-      if (context?.previous) {
+      // 조회 전 토글이라 캐시가 없던 경우(previous가 undefined)엔 낙관적으로 써넣은 값을
+      // 지워 원상복구한다. 캐시가 있었으면 그 스냅샷으로 되돌린다.
+      if (context?.previous === undefined) {
+        queryClient.removeQueries({ queryKey: queryKeys.user.savedStores() });
+      } else {
         queryClient.setQueryData(
           queryKeys.user.savedStores(),
           context.previous,

--- a/src/mocks/saved.ts
+++ b/src/mocks/saved.ts
@@ -1,13 +1,7 @@
 import { MOCK_COURSE, MOCK_COURSE_FALLBACK } from "@/mocks/courses";
-import { MOCK_PLACES } from "@/mocks/places";
 import type { Course, SavedCoursePreview } from "@/types/course";
-import type { Place } from "@/types/place";
 
-// 저장(플로우 C) 화면 개발용 목. 실연동 시 이 파일만 지우면 되도록 Place/Course 외 타입을 만들지 말 것.
-
-export const MOCK_SAVED_PLACES: Place[] = ["p-002", "p-001", "p-004", "p-016"]
-  .map((id) => MOCK_PLACES.find((place) => place.id === id))
-  .filter((place): place is Place => place !== undefined);
+// 저장(플로우 C) 코스 탭 개발용 목. 장소 저장은 실연동됨 — 코스 API 연동 시 이 파일 삭제.
 
 function toPreview(
   course: Course,

--- a/src/mocks/user.ts
+++ b/src/mocks/user.ts
@@ -1,9 +1,8 @@
 import { MOCK_PLACES } from "@/mocks/places";
 import { getMyReviews } from "@/mocks/reviews";
-import type { PassportStamp, UserSummary } from "@/types/user";
+import type { PassportStamp } from "@/types/user";
 
-// 마이(플로우 D) 화면 개발용 목. 리뷰수·도장수는 getMyReviews에서 파생(화면 간 일관).
-// 실연동 시 이 파일만 지우면 되도록 User 외의 타입을 만들지 말 것.
+// 마이(플로우 D) 여권 개발용 목. 프로필(GET /user/me)은 실연동됨 — 여권 API 연동 시 이 파일 삭제.
 
 const storeName = (placeId: string) =>
   MOCK_PLACES.find((place) => place.id === placeId)?.name ?? "";
@@ -20,12 +19,6 @@ export const MOCK_PASSPORT: PassportStamp[] = getMyReviews()
     photoUrl: review.id === "r-010" ? null : review.photoUrl,
     createdAt: review.createdAt,
   }));
-
-export const MOCK_USER: UserSummary = {
-  nickname: "나영",
-  reviewCount: getMyReviews().length,
-  stampCount: MOCK_PASSPORT.length,
-};
 
 export function getStamp(id: string): PassportStamp | undefined {
   return MOCK_PASSPORT.find((stamp) => stamp.id === id);


### PR DESCRIPTION
## 🎯 작업 내용

마이 탭 프로필과 장소 저장(북마크)을 백엔드에 연동했습니다. #30에서 UI만 있던 것을 실동작으로 완성했습니다. 조회에는 `demo=true`를 유지하고, 서버 응답은 도메인 함수 경계(`src/api/store.ts`)에서 앱 타입으로 매핑합니다.

저장 목록은 지도 카드와 같은 `StoreCardResponse[]`라 기존 `mapStoreCard`를 재사용합니다. 가게 상세 ♡와 저장 탭은 같은 캐시(`queryKeys.user.savedStores`)를 공유해, 한쪽에서 토글하면 양쪽이 함께 반영됩니다.

> ⚠️ **이번 범위 제외:** 코스 저장(`/user/me/saved-courses`·저장 탭 코스 탭)은 여권/코스·추천 API 배포 대기라 제외했습니다. 코스 탭은 목(`MOCK_SAVED_COURSES`) 그대로 두고, 후속 이슈에서 연동합니다.

## 📝 변경 사항

### `GET /user/me` — 마이 프로필

- `src/hooks/use-my-profile-query.ts` (정의만 있던 훅을 실사용)
- `src/app/(main)/my.tsx` (`MOCK_USER` → 실 API, 로딩/에러 상태 추가)

### `DELETE /user/me` — 회원 탈퇴

- `src/hooks/use-delete-account-mutation.ts` (성공 시 캐시 clear, `deleteUser`가 토큰 정리)
- `src/app/(main)/my.tsx` (탈퇴 확인 → 성공 시 토스트·`/login` 이동, 실패 시 세션 유지)
- `src/mocks/user.ts` (`MOCK_USER` 제거 — 여권 목은 유지)

### `GET /user/store` — 저장 장소 목록

- `src/api/store.ts` (`getSavedStores` — `mapStoreCard` 재사용)
- `src/hooks/use-saved-stores-query.ts`
- `src/app/(main)/saved.tsx` (`useState(MOCK_SAVED_PLACES)` → 실 API, 로딩/에러 상태)
- `src/mocks/saved.ts` (`MOCK_SAVED_PLACES` 제거 — 코스 목은 유지)

### `POST`·`DELETE /stores/{storeId}/save` — 장소 저장/해제 토글

- `src/api/store.ts` (`saveStore`·`unsaveStore`)
- `src/hooks/use-toggle-saved-store-mutation.ts` (저장목록 캐시 낙관적 갱신·실패 롤백, 저장/해제·실패 토스트)
- `src/app/store/[placeId]/index.tsx` (♡ 로컬 state → 저장목록 파생 + 토글)
- `src/app/(main)/saved.tsx` (삭제 메뉴 → 해제 토글)

### `GET /user/me` 재사용 — 마이 리뷰 총 리뷰수 (#29 후속)

- #29 에서 예고한 후속 작업입니다. 마이 리뷰 상단 "N건"을 로드된 개수(`reviews.length`)가 아니라 `GET /user/me`의 `reviewCount`(총계)로 표기합니다.

- `src/app/my/reviews.tsx` (총계 소스 교체, 삭제 시 총계 낙관적 -1·실패 롤백)
- `src/hooks/use-delete-review-mutation.ts` (삭제 성공 시 `queryKeys.user.me()` 무효화 → 서버 총계 재동기화)

## 🔗 관련 이슈

- Closes #30

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 타입 에러가 없나요? (`npm run typecheck`)
- [x] 불필요한 콘솔 로그(`console.log`)를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📦 네이티브 / 설정 변경 (해당 시)

- 해당 없음 (신규 의존성·env·네이티브 설정 변경 없음)

## 📱 동작 확인 (테스트한 플랫폼 체크)

- [x] Android — 에뮬레이터에서 프로필 표시 · 저장/해제 토글(상세 ♡ ↔ 저장 탭 동기화) · 저장 목록 · 회원 탈퇴(토큰 정리·로그인 복귀) 확인

## 📸 스크린샷 / 화면 녹화

<!-- 마이 프로필·저장 목록·상세 ♡ 토글·탈퇴 플로우 캡처 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 저장한 장소를 서버에서 조회하고 저장·해제할 수 있습니다.
  - 프로필 정보를 서버에서 확인하고 회원 탈퇴를 진행할 수 있습니다.
  - 리뷰 화면에서 전체 리뷰 수가 표시되며, 리뷰 삭제 결과가 즉시 반영됩니다.

- **버그 수정**
  - 저장한 장소, 장소 상세, 리뷰 화면의 로딩 및 오류 상태와 재시도 기능을 개선했습니다.
  - 저장·삭제 요청 실패 시 화면 데이터가 이전 상태로 복원됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->